### PR TITLE
AQ1: headless config schema v1

### DIFF
--- a/docs/headless-runtime.md
+++ b/docs/headless-runtime.md
@@ -1,0 +1,115 @@
+# Andy CLI headless runtime
+
+`andy-cli` has two modes:
+
+- **Interactive** (existing): `andy-cli` — TTY-driven, user-facing. The standalone assistant.
+- **Headless** (introduced by Epic AQ, rivoli-ai/andy-cli#44): `andy-cli run --headless --config <path>` — non-interactive, spawned by rivoli-ai/andy-containers' run configurator (Epic AP). Emits a structured event stream, writes an output file, exits with a typed status code.
+
+This document covers the headless contract: the config schema (AQ1), the event stream (AQ3), the output contract (AQ4), and the exit semantics (AQ2/AQ5).
+
+## Config schema — v1
+
+**Canonical spec:** [`schemas/headless-config.v1.json`](../schemas/headless-config.v1.json) (JSON Schema draft 2020-12, `$id = https://rivoli-ai.com/schemas/andy-cli/headless-config.v1.json`).
+
+**Samples:** [`schemas/samples/*.json`](../schemas/samples/) — three fixtures covering the `triage-agent`, `planning-agent`, and `coding-agent` shapes. Each validates against the schema via [`HeadlessConfigSchemaTests`](../tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigSchemaTests.cs).
+
+### Shape
+
+```jsonc
+{
+  "schema_version": 1,                    // const; v2 ships a new file
+  "run_id": "uuid",                       // correlates with andy-containers Run (#103)
+  "agent": {
+    "slug": "triage-agent",               // from andy-agents Epic W
+    "revision": 3,                        // optional version pin
+    "instructions": "...",                // system prompt (agent base + delegation contract.objective)
+    "output_format": "json-triage-v1"     // optional label or schema ref
+  },
+  "model": {
+    "provider": "anthropic",              // enum: anthropic|openai|google|cerebras|local
+    "id": "claude-sonnet-4-6",
+    "api_key_ref": "env:ANDY_MODEL_KEY"   // resolve from env / secret-store
+  },
+  "tools": [                              // resolved from agent.skills × allowed_tools
+    { "name": "issues.get", "transport": "mcp", "endpoint": "https://mcp/issues.get" },
+    { "name": "repo.search", "transport": "cli", "binary": "andy-issues-cli", "command": ["andy-issues-cli", "search"] }
+  ],
+  "workspace": { "root": "/workspace", "branch": "main" },
+  "env_vars": { "RIVOLI_TENANT_ID": "..." },
+  "output":   { "file": "/workspace/.andy-run/output.json", "stream": "stdout" },
+  "event_sink": {
+    "nats_subject": "andy.containers.events.run.{run_id}.progress"
+  },
+  "policy_id": "uuid",                    // andy-rbac Epic V
+  "boundaries": ["read-only"],
+  "limits": { "max_iterations": 50, "timeout_seconds": 300 }
+}
+```
+
+### Field notes
+
+- **`schema_version`** — bumping to v2 introduces a new schema file (`v2.json`) and a compatibility layer in the loader. Do not overload v1.
+- **`agent.slug`** — lowercase slugs matching `^[a-z][a-z0-9-]{1,63}$`. Enforced by schema.
+- **`tools[].transport`** — only `mcp` and `cli` are supported. MCP calls go through mcp-gateway (Epic Y); CLI transports exec the named binary as a subprocess.
+- **`output.stream`** — `stdout` (default) or `fifo`. When `fifo`, the path is in `event_sink.path`; andy-containers creates the FIFO before spawning the agent.
+- **`event_sink.nats_subject`** — **informational**. The agent does not publish to NATS directly. andy-containers (Epic AP6) fans agent stdout → NATS subject.
+- **`boundaries`** — tags derived from the bound policy; runtime guard-rails, not authoritative. Real policy evaluation happens server-side at each tool call (per Epic V).
+- **`limits.max_iterations`** — hard cap on agent loop iterations. Exceeded → exit code 4.
+- **`limits.timeout_seconds`** — wall-clock timeout. Exceeded → exit code 4.
+
+### Reserved env vars (injected by container runtime, Epic Y5)
+
+- `ANDY_PROXY_URL` — unified proxy base URL.
+- `ANDY_TOKEN` — run-scoped auth token (Epic Y6 lifecycle).
+- `ANDY_MCP_URL` — mcp-gateway base URL.
+
+These are guaranteed present by the container image; the config's `env_vars` object MUST NOT shadow them.
+
+## Invocation
+
+```sh
+andy-cli run --headless --config /workspace/.andy-run/config.json
+```
+
+Exit codes (pinned by AQ2):
+
+| Code | Meaning |
+|---|---|
+| 0 | Success — output file written, event stream complete |
+| 1 | Agent-level failure (LLM refused, tool-call chain failed, output validation failed) |
+| 2 | Config error (schema violation, missing required files, unresolvable api_key_ref) |
+| 3 | Cancelled (SIGTERM or `andy-cli cancel --run-id`) |
+| 4 | Timeout (`max_iterations` or `timeout_seconds` exceeded) |
+| 5 | Internal error (bug) |
+
+## Event stream (AQ3)
+
+Each agent step emits one NDJSON line: `{ts, kind, data}`. Kinds (to be pinned in AQ3):
+
+- `started` — run starting; payload carries resolved model / tool list.
+- `tool_call_started` / `tool_call_finished` — tool invocations with args/result digests.
+- `llm_chunk` — streaming LLM output (if `output_format: plain` or streaming is enabled).
+- `output_written` — final output file written and fsynced.
+- `error` — recoverable or terminal error.
+- `finished` — run complete (always emitted before exit, even on failure).
+
+Full event schema lands with AQ3 (`schemas/headless-events.v1.json`).
+
+## Output file (AQ4)
+
+- Written to `output.file` path from config.
+- Atomic write (tmp + rename).
+- Free-form text OR structured JSON matching the `output_format` schema hint.
+- On non-zero exit the file MAY be absent (no partial writes for structured outputs).
+
+## Cross-repo links
+
+| What | Where |
+|---|---|
+| Epic AQ (this epic) | rivoli-ai/andy-cli#44 |
+| AQ1 — config schema | rivoli-ai/andy-cli#46 |
+| Run entity (the thing correlated by `run_id`) | rivoli-ai/andy-containers#103 |
+| Epic AP — configurator + headless runner | rivoli-ai/andy-containers#101 |
+| Epic Y5 — container env injection | rivoli-ai/andy-mcp-gateway#8 |
+| Epic Y6 — run-scoped token lifecycle | rivoli-ai/andy-mcp-gateway#9 |
+| Agent spec source of truth | rivoli-ai/andy-agents Epic W |

--- a/schemas/headless-config.v1.json
+++ b/schemas/headless-config.v1.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rivoli-ai.com/schemas/andy-cli/headless-config.v1.json",
+  "title": "Andy CLI headless run config v1",
+  "description": "Schema for the config file consumed by `andy-cli run --headless --config <path>`. See Epic AQ (rivoli-ai/andy-cli#44) and docs/headless-runtime.md for the full semantics.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "agent",
+    "model",
+    "tools",
+    "workspace",
+    "output",
+    "limits"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": 1,
+      "description": "Schema version. Bump to 2 introduces a new schema file (v2.json) and a separate compatibility layer; do not overload v1."
+    },
+    "run_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Correlates stdout events and artifacts with the andy-containers Run entity (rivoli-ai/andy-containers#103)."
+    },
+    "agent": {
+      "type": "object",
+      "required": ["slug", "instructions"],
+      "additionalProperties": false,
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]{1,63}$",
+          "description": "Agent identifier from andy-agents (Epic W W5 seed). Lowercase ASCII, dash-separated, 2-64 chars."
+        },
+        "revision": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional pin to a specific agent revision. Null/absent = head."
+        },
+        "instructions": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100000,
+          "description": "Resolved system prompt: agent.instructions concatenated with delegation_contract.objective."
+        },
+        "output_format": {
+          "type": "string",
+          "description": "Optional hint for the agent's final output: a free-form label like 'plain' or a schema reference like 'json-triage-output-v1'."
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["provider", "id"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "enum": ["anthropic", "openai", "google", "cerebras", "local"],
+          "description": "LLM provider. Pluggable via Andy.Llm adapter registry."
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Model identifier as recognised by the provider (e.g. 'claude-sonnet-4-6', 'gpt-5-medium')."
+        },
+        "api_key_ref": {
+          "type": "string",
+          "description": "How to resolve the API key. Supported prefixes: 'env:NAME' (read env var), 'secret-store:NAME' (future). Never the bare key value."
+        }
+      }
+    },
+    "tools": {
+      "type": "array",
+      "description": "Concrete tool bindings this run is allowed to call, resolved from the agent's skills × allowed_tools.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "MCP tool binding",
+            "required": ["name", "transport", "endpoint"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_.-]*$",
+                "description": "Tool identifier as seen by the agent."
+              },
+              "transport": { "const": "mcp" },
+              "endpoint": {
+                "type": "string",
+                "format": "uri",
+                "description": "mcp-gateway URL for this tool (usually $ANDY_MCP_URL/<tool-name>)."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "CLI tool binding",
+            "required": ["name", "transport", "binary"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_.-]*$"
+              },
+              "transport": { "const": "cli" },
+              "binary": {
+                "type": "string",
+                "description": "Executable name resolved via $PATH (e.g. 'andy-tasks-cli')."
+              },
+              "command": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Default argv the agent prepends. The agent appends its own args."
+              }
+            }
+          }
+        ]
+      }
+    },
+    "workspace": {
+      "type": "object",
+      "required": ["root"],
+      "additionalProperties": false,
+      "properties": {
+        "root": {
+          "type": "string",
+          "description": "Absolute path inside the container to the mounted workspace (typically /workspace)."
+        },
+        "branch": {
+          "type": "string",
+          "description": "Git branch the run operates on."
+        }
+      }
+    },
+    "env_vars": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Additional env vars injected into the agent process. Reserved: ANDY_PROXY_URL, ANDY_TOKEN, ANDY_MCP_URL are always set by the container runtime (Epic Y5)."
+    },
+    "output": {
+      "type": "object",
+      "required": ["file", "stream"],
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Path to write the final structured output. Atomic write (tmp + rename). Absent on failure before output stage."
+        },
+        "stream": {
+          "enum": ["stdout", "fifo"],
+          "description": "Where the structured event stream goes. 'stdout' is the default; 'fifo' names a separate path (set via event_sink.path)."
+        }
+      }
+    },
+    "event_sink": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nats_subject": {
+          "type": "string",
+          "pattern": "^andy\\.containers\\.events\\.run\\.[0-9a-f-]+\\.[a-z_]+$",
+          "description": "NATS subject the container runtime (Epic AP6) will fan events to. Agent does not publish directly."
+        },
+        "path": {
+          "type": "string",
+          "description": "Absolute path to a named FIFO when output.stream == 'fifo'."
+        }
+      }
+    },
+    "policy_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Resolved policy UUID from andy-rbac (Epic V). Null-ish until V lands platform-wide."
+    },
+    "boundaries": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Policy-derived boundary tags (e.g. 'read-only', 'no-prod', 'draft-only'). Runtime uses these as guard-rails; the authoritative evaluation happens server-side at each tool call."
+    },
+    "limits": {
+      "type": "object",
+      "required": ["max_iterations", "timeout_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "max_iterations": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000,
+          "description": "Hard cap on agent loop iterations. Exceeded = exit code 4 (timeout)."
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 86400,
+          "description": "Wall-clock timeout. Exceeded = exit code 4 (timeout)."
+        }
+      }
+    }
+  }
+}

--- a/schemas/samples/coding-headless.json
+++ b/schemas/samples/coding-headless.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "run_id": "00000000-0000-0000-0000-000000000003",
+  "agent": {
+    "slug": "coding-agent",
+    "instructions": "You are the coding agent. Implement the assigned TaskNode against the delegation contract. Write tests and run them before declaring done.",
+    "output_format": "plain"
+  },
+  "model": {
+    "provider": "anthropic",
+    "id": "claude-sonnet-4-6",
+    "api_key_ref": "env:ANDY_MODEL_KEY"
+  },
+  "tools": [
+    {
+      "name": "fs.patch",
+      "transport": "mcp",
+      "endpoint": "https://mcp.internal/tools/fs.patch"
+    },
+    {
+      "name": "git.branch",
+      "transport": "cli",
+      "binary": "git",
+      "command": ["git"]
+    },
+    {
+      "name": "container.exec",
+      "transport": "mcp",
+      "endpoint": "https://mcp.internal/tools/container.exec"
+    },
+    {
+      "name": "test.run",
+      "transport": "cli",
+      "binary": "andy-containers-cli",
+      "command": ["andy-containers-cli", "exec", "--"]
+    }
+  ],
+  "workspace": {
+    "root": "/workspace",
+    "branch": "feature/auto-coding-run"
+  },
+  "env_vars": {
+    "DOTNET_NOLOGO": "1",
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1"
+  },
+  "output": {
+    "file": "/workspace/.andy-run/output.json",
+    "stream": "stdout"
+  },
+  "boundaries": ["write-branch", "sandboxed"],
+  "limits": {
+    "max_iterations": 400,
+    "timeout_seconds": 3600
+  }
+}

--- a/schemas/samples/planning-headless.json
+++ b/schemas/samples/planning-headless.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "run_id": "00000000-0000-0000-0000-000000000002",
+  "agent": {
+    "slug": "planning-agent",
+    "instructions": "You are the planning agent. Given a triaged issue and the matching WorkflowTemplate, decompose it into TaskNodes with skill + agent + env assignments. Write the result as plan.md via docs.put.",
+    "output_format": "json-plan-v1"
+  },
+  "model": {
+    "provider": "anthropic",
+    "id": "claude-opus-4-7",
+    "api_key_ref": "env:ANDY_MODEL_KEY"
+  },
+  "tools": [
+    {
+      "name": "docs.search",
+      "transport": "mcp",
+      "endpoint": "https://mcp.internal/tools/docs.search"
+    },
+    {
+      "name": "docs.put",
+      "transport": "mcp",
+      "endpoint": "https://mcp.internal/tools/docs.put"
+    },
+    {
+      "name": "tasks.templates.get",
+      "transport": "cli",
+      "binary": "andy-tasks-cli",
+      "command": ["andy-tasks-cli", "templates", "get"]
+    }
+  ],
+  "workspace": {
+    "root": "/workspace",
+    "branch": "main"
+  },
+  "output": {
+    "file": "/workspace/.andy-run/output.json",
+    "stream": "stdout"
+  },
+  "boundaries": ["draft-only"],
+  "limits": {
+    "max_iterations": 120,
+    "timeout_seconds": 900
+  }
+}

--- a/schemas/samples/triage-headless.json
+++ b/schemas/samples/triage-headless.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "run_id": "00000000-0000-0000-0000-000000000001",
+  "agent": {
+    "slug": "triage-agent",
+    "revision": 3,
+    "instructions": "You are the triage agent. Classify incoming issues against the Rivoli template set (bug-fix, feature, incident-response, upgrade) and return a structured JSON result matching json-triage-output-v1.",
+    "output_format": "json-triage-output-v1"
+  },
+  "model": {
+    "provider": "anthropic",
+    "id": "claude-sonnet-4-6",
+    "api_key_ref": "env:ANDY_MODEL_KEY"
+  },
+  "tools": [
+    {
+      "name": "issues.get",
+      "transport": "mcp",
+      "endpoint": "https://mcp.internal/tools/issues.get"
+    },
+    {
+      "name": "repo.search",
+      "transport": "cli",
+      "binary": "andy-issues-cli",
+      "command": ["andy-issues-cli", "search"]
+    }
+  ],
+  "workspace": {
+    "root": "/workspace",
+    "branch": "main"
+  },
+  "env_vars": {
+    "RIVOLI_TENANT_ID": "tenant-acme"
+  },
+  "output": {
+    "file": "/workspace/.andy-run/output.json",
+    "stream": "stdout"
+  },
+  "event_sink": {
+    "nats_subject": "andy.containers.events.run.00000000-0000-0000-0000-000000000001.progress"
+  },
+  "policy_id": "11111111-2222-3333-4444-555555555555",
+  "boundaries": ["read-only"],
+  "limits": {
+    "max_iterations": 50,
+    "timeout_seconds": 300
+  }
+}

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="JsonSchema.Net" Version="9.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -55,6 +56,18 @@
     <Compile Include="ACP/AndyAgentProviderTests.cs" />
     <!-- Multi-turn conversation context tests -->
     <Compile Include="Integration/MultiTurnToolCallContextTests.cs" />
+    <!-- AQ1 headless config schema tests (rivoli-ai/andy-cli#46) -->
+    <Compile Include="HeadlessConfig/HeadlessConfigSchemaTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- AQ1 schema + fixtures — needed at test runtime to validate fixtures. -->
+    <None Include="..\..\schemas\headless-config.v1.json" Link="schemas\headless-config.v1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\schemas\samples\*.json" Link="schemas\samples\%(Filename).json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigSchemaTests.cs
+++ b/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigSchemaTests.cs
@@ -1,0 +1,313 @@
+// AQ1 tests — validate the headless config JSON Schema v1 (rivoli-ai/andy-cli#46).
+//
+// Exercises the contract the andy-containers configurator (Epic AP4) will write
+// and `andy-cli run --headless --config <path>` (AQ2) will consume. Whenever the
+// JSON Schema changes, positive fixtures and negative cases both live here so a
+// breaking change is loud at CI time, not at runtime in a container.
+
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+using Xunit;
+
+namespace Andy.Cli.Tests.HeadlessConfig;
+
+public class HeadlessConfigSchemaTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string SchemaPath = Path.Combine(RepoRoot, "schemas", "headless-config.v1.json");
+    private static readonly string SamplesDir = Path.Combine(RepoRoot, "schemas", "samples");
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Andy.Cli.sln")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is null)
+        {
+            throw new InvalidOperationException("Could not locate Andy.Cli.sln walking up from test output directory.");
+        }
+        return dir.FullName;
+    }
+
+    // JsonSchema.Net registers schemas by $id and throws on re-registration.
+    // Cache the parsed schema so every test shares one instance.
+    private static readonly Lazy<JsonSchema> s_schema = new(() =>
+        JsonSchema.FromFile(SchemaPath));
+
+    private static JsonSchema LoadSchema() => s_schema.Value;
+
+    private static JsonNode LoadJson(string path)
+    {
+        var text = File.ReadAllText(path);
+        var node = JsonNode.Parse(text);
+        if (node is null)
+        {
+            throw new InvalidOperationException($"JSON at {path} parsed to null.");
+        }
+        return node;
+    }
+
+    [Theory]
+    [InlineData("triage-headless.json")]
+    [InlineData("planning-headless.json")]
+    [InlineData("coding-headless.json")]
+    public void FixtureValidatesAgainstSchema(string fixtureName)
+    {
+        var schema = LoadSchema();
+        var node = LoadJson(Path.Combine(SamplesDir, fixtureName));
+
+        var result = schema.Evaluate(ToElement(node), new EvaluationOptions
+        {
+            OutputFormat = OutputFormat.List
+        });
+
+        Assert.True(result.IsValid,
+            $"Fixture {fixtureName} failed schema validation: {FormatErrors(result)}");
+    }
+
+    [Fact]
+    public void SchemaVersion_MustBeExactly1()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["schema_version"] = 2;
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "schema_version != 1 must be rejected");
+    }
+
+    [Fact]
+    public void AgentSlug_RejectsUppercase()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["agent"]!["slug"] = "Triage-Agent";
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "agent.slug must be lowercase-only");
+    }
+
+    [Fact]
+    public void AgentSlug_RejectsLeadingDigit()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["agent"]!["slug"] = "1triage";
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "agent.slug must begin with a letter");
+    }
+
+    [Fact]
+    public void MissingRequired_RunId_Rejected()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config.AsObject().Remove("run_id");
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "run_id is required");
+    }
+
+    [Fact]
+    public void MissingRequired_Limits_Rejected()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config.AsObject().Remove("limits");
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "limits is required");
+    }
+
+    [Fact]
+    public void McpToolBinding_Validates()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["tools"] = new JsonArray(
+            new JsonObject
+            {
+                ["name"] = "issues.get",
+                ["transport"] = "mcp",
+                ["endpoint"] = "https://mcp.internal/issues.get"
+            });
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.True(result.IsValid, FormatErrors(result));
+    }
+
+    [Fact]
+    public void CliToolBinding_Validates()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["tools"] = new JsonArray(
+            new JsonObject
+            {
+                ["name"] = "tasks.list",
+                ["transport"] = "cli",
+                ["binary"] = "andy-tasks-cli",
+                ["command"] = new JsonArray("andy-tasks-cli", "list")
+            });
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.True(result.IsValid, FormatErrors(result));
+    }
+
+    [Fact]
+    public void ToolBinding_RejectsUnknownTransport()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["tools"] = new JsonArray(
+            new JsonObject
+            {
+                ["name"] = "weird.tool",
+                ["transport"] = "websocket",
+                ["endpoint"] = "ws://example/weird"
+            });
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "transport must be 'mcp' or 'cli'");
+    }
+
+    [Fact]
+    public void McpToolBinding_MissingEndpoint_Rejected()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["tools"] = new JsonArray(
+            new JsonObject
+            {
+                ["name"] = "issues.get",
+                ["transport"] = "mcp"
+                // endpoint absent
+            });
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "MCP binding requires endpoint");
+    }
+
+    [Fact]
+    public void Model_RejectsUnknownProvider()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["model"]!["provider"] = "cohere";
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "model.provider enum is closed");
+    }
+
+    [Fact]
+    public void Limits_MaxIterationsZero_Rejected()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["limits"]!["max_iterations"] = 0;
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "max_iterations must be >= 1");
+    }
+
+    [Fact]
+    public void Limits_TimeoutExceedsDay_Rejected()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["limits"]!["timeout_seconds"] = 86401;
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "timeout_seconds must be <= 86400 (one day)");
+    }
+
+    [Fact]
+    public void AdditionalProperties_Rejected()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["something_extra"] = "should be rejected";
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "top-level additionalProperties: false");
+    }
+
+    [Fact]
+    public void EventSinkSubject_RejectsWrongNamespace()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["event_sink"] = new JsonObject
+        {
+            ["nats_subject"] = "andy.tasks.events.goal.abc.planned"
+        };
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "event_sink.nats_subject must live in andy.containers.events.run.*");
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    /// <summary>
+    /// Converts a <see cref="JsonNode"/> tree into a <see cref="JsonElement"/>
+    /// so it can be passed to <see cref="JsonSchema.Evaluate(JsonElement,
+    /// EvaluationOptions?)"/>. JsonSchema.Net 9.x's primary overload is
+    /// element-based; doing one conversion here keeps tests readable.
+    /// </summary>
+    private static JsonElement ToElement(JsonNode node)
+        => JsonDocument.Parse(node.ToJsonString()).RootElement;
+
+    private static JsonObject MinimalValidConfig() => new()
+    {
+        ["schema_version"] = 1,
+        ["run_id"] = "00000000-0000-0000-0000-0000000000ff",
+        ["agent"] = new JsonObject
+        {
+            ["slug"] = "triage-agent",
+            ["instructions"] = "Classify issues."
+        },
+        ["model"] = new JsonObject
+        {
+            ["provider"] = "anthropic",
+            ["id"] = "claude-sonnet-4-6"
+        },
+        ["tools"] = new JsonArray(),
+        ["workspace"] = new JsonObject
+        {
+            ["root"] = "/workspace"
+        },
+        ["output"] = new JsonObject
+        {
+            ["file"] = "/tmp/out.json",
+            ["stream"] = "stdout"
+        },
+        ["limits"] = new JsonObject
+        {
+            ["max_iterations"] = 50,
+            ["timeout_seconds"] = 300
+        }
+    };
+
+    private static string FormatErrors(EvaluationResults results)
+    {
+        var writer = new StringWriter();
+        if (results.Details is null)
+        {
+            return results.IsValid ? "(valid)" : "(invalid, no details available)";
+        }
+        foreach (var detail in results.Details)
+        {
+            if (detail.IsValid) continue;
+            var errors = detail.Errors is null
+                ? "(no errors)"
+                : string.Join("; ", detail.Errors.Select(kv => $"{kv.Key}={kv.Value}"));
+            writer.WriteLine($"  {detail.EvaluationPath}: {errors}");
+        }
+        return writer.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `schemas/headless-config.v1.json` — JSON Schema draft 2020-12 defining the contract between `andy-cli run --headless` (AQ2) and the rivoli-ai/andy-containers configurator (Epic AP, AP4)
- Three representative fixtures (triage / planning / coding agents)
- Full validation test coverage including negative cases
- `docs/headless-runtime.md` with field-by-field walkthrough, reserved env vars, invocation, exit codes

Closes rivoli-ai/andy-cli#46.

## Test plan
- [x] 17 new tests in `HeadlessConfigSchemaTests` — fixtures validate; schema_version const; agent.slug pattern; required fields; closed enums; tool oneOf (mcp / cli); limit ranges; additionalProperties; NATS subject pattern
- [x] Full test suite: 237 pass / 1 skipped / 0 fail

## Not included (sibling stories)
- AQ2 `andy-cli run --headless` command
- AQ3 event-stream schema
- AQ4 output-file atomic write
- AQ5 cancel protocol
- AQ6 MCP + CLI tool transports at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)