### PR TITLE
AQ2: andy-cli run --headless --config command (#47)

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />
     <PackageReference Include="Andy.Tui" Version="2025.10.24-rc.39" />
     <PackageReference Include="JsonRepairSharp" Version="1.2.3" />
+    <PackageReference Include="JsonSchema.Net" Version="9.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
@@ -34,6 +35,18 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <!--
+    Embed the AQ1 headless-config schema so andy-cli run (headless mode)
+    can validate without depending on the schemas/ directory at runtime.
+    LogicalName is load-bearing: HeadlessConfigLoader looks it up by this
+    exact string.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\schemas\headless-config.v1.json">
+      <LogicalName>Andy.Cli.schemas.headless-config.v1.json</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Andy.Cli/HeadlessConfig/HeadlessConfigLoader.cs
+++ b/src/Andy.Cli/HeadlessConfig/HeadlessConfigLoader.cs
@@ -1,0 +1,177 @@
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+
+namespace Andy.Cli.HeadlessConfig;
+
+// Loads and validates a headless run config file against the AQ1 schema
+// (embedded at build time from schemas/headless-config.v1.json). Returns a
+// parsed HeadlessRunConfig on success or a human-readable error string on
+// any failure — the caller (HeadlessRunner) maps failures to
+// HeadlessExitCode.ConfigError so the exit-code contract stays in one
+// place.
+public static class HeadlessConfigLoader
+{
+    // The schema ships embedded (not read from disk at runtime) so a
+    // published binary doesn't depend on the schemas/ directory being
+    // present alongside it. LogicalName is pinned in the .csproj.
+    private const string EmbeddedSchemaName = "Andy.Cli.schemas.headless-config.v1.json";
+
+    private static readonly Lazy<JsonSchema> s_schema = new(LoadEmbeddedSchema);
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = false,
+    };
+
+    public static async Task<HeadlessConfigLoadResult> TryLoadAsync(
+        string path,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return HeadlessConfigLoadResult.Fail("Config path is empty.");
+        }
+
+        if (!File.Exists(path))
+        {
+            return HeadlessConfigLoadResult.Fail($"Config file not found: {path}");
+        }
+
+        string text;
+        try
+        {
+            text = await File.ReadAllTextAsync(path, ct);
+        }
+        catch (IOException ex)
+        {
+            return HeadlessConfigLoadResult.Fail($"Failed to read config file: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return HeadlessConfigLoadResult.Fail($"Permission denied reading config: {ex.Message}");
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(text);
+        }
+        catch (JsonException ex)
+        {
+            return HeadlessConfigLoadResult.Fail($"Config is not valid JSON: {ex.Message}");
+        }
+        if (node is null)
+        {
+            return HeadlessConfigLoadResult.Fail("Config parsed to null (empty document).");
+        }
+
+        // Schema validation must happen against a JsonElement tree; JsonSchema.Net
+        // 9.x's primary overload is element-based. Convert once so error formatting
+        // and deserialization can share the same underlying bytes.
+        var element = JsonDocument.Parse(node.ToJsonString()).RootElement;
+        var result = s_schema.Value.Evaluate(element, new EvaluationOptions
+        {
+            OutputFormat = OutputFormat.List,
+        });
+
+        if (!result.IsValid)
+        {
+            return HeadlessConfigLoadResult.Fail(
+                "Config does not match headless-config.v1 schema:"
+                    + Environment.NewLine
+                    + FormatSchemaErrors(result));
+        }
+
+        HeadlessRunConfig? config;
+        try
+        {
+            config = JsonSerializer.Deserialize<HeadlessRunConfig>(text, s_jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            // The schema should have caught structural problems already; a failure
+            // here typically means a type-level mismatch (e.g. unparseable Guid) that
+            // the schema allows but System.Text.Json can't coerce.
+            return HeadlessConfigLoadResult.Fail(
+                $"Config passed schema validation but failed to deserialize: {ex.Message}");
+        }
+
+        if (config is null)
+        {
+            return HeadlessConfigLoadResult.Fail("Config deserialization returned null.");
+        }
+
+        return HeadlessConfigLoadResult.Ok(config);
+    }
+
+    // Schema $id declared in schemas/headless-config.v1.json. Kept as a local
+    // constant so the registry-collision fallback below doesn't re-parse the
+    // file to discover it.
+    private static readonly Uri SchemaId = new("https://rivoli-ai.com/schemas/andy-cli/headless-config.v1.json");
+
+    private static JsonSchema LoadEmbeddedSchema()
+    {
+        var assembly = typeof(HeadlessConfigLoader).Assembly;
+        using var stream = assembly.GetManifestResourceStream(EmbeddedSchemaName);
+        if (stream is null)
+        {
+            throw new InvalidOperationException(
+                $"Embedded headless-config schema '{EmbeddedSchemaName}' not found. "
+                    + "Check that Andy.Cli.csproj still embeds schemas/headless-config.v1.json.");
+        }
+        using var reader = new StreamReader(stream);
+        var text = reader.ReadToEnd();
+
+        try
+        {
+            return JsonSchema.FromText(text);
+        }
+        catch (Exception) when (SchemaRegistry.Global.Get(SchemaId) is JsonSchema existing)
+        {
+            // JsonSchema.FromText auto-registers against the process-global
+            // SchemaRegistry by $id and throws (JsonSchemaException, not the
+            // ArgumentException one might expect) when the $id is already
+            // taken. That happens in a single test run where AQ1's schema
+            // fixtures already called FromFile/FromText on the same file.
+            // Reuse whichever instance got there first — content is identical
+            // by construction.
+            return existing;
+        }
+    }
+
+    private static string FormatSchemaErrors(EvaluationResults results)
+    {
+        var writer = new StringWriter();
+        if (results.Details is null)
+        {
+            return results.IsValid ? "(valid)" : "(invalid, no details available)";
+        }
+        foreach (var detail in results.Details)
+        {
+            if (detail.IsValid) continue;
+            var errors = detail.Errors is null
+                ? "(no errors)"
+                : string.Join("; ", detail.Errors.Select(kv => $"{kv.Key}={kv.Value}"));
+            writer.WriteLine($"  {detail.EvaluationPath}: {errors}");
+        }
+        return writer.ToString();
+    }
+}
+
+public sealed record HeadlessConfigLoadResult
+{
+    public HeadlessRunConfig? Config { get; init; }
+    public string? Error { get; init; }
+
+    public bool IsSuccess => Config is not null && Error is null;
+
+    public static HeadlessConfigLoadResult Ok(HeadlessRunConfig config) =>
+        new() { Config = config };
+
+    public static HeadlessConfigLoadResult Fail(string error) =>
+        new() { Error = error };
+}

--- a/src/Andy.Cli/HeadlessConfig/HeadlessExitCode.cs
+++ b/src/Andy.Cli/HeadlessConfig/HeadlessExitCode.cs
@@ -1,0 +1,15 @@
+namespace Andy.Cli.HeadlessConfig;
+
+// Structured process exit codes for `andy-cli run --headless`, per the AQ2
+// contract (rivoli-ai/andy-cli#47). Consumers in andy-containers (Epic AP
+// configurator + captor) key off these values to decide retry/cancel/
+// report semantics — changing a mapping is a breaking cross-repo change.
+public enum HeadlessExitCode
+{
+    Success = 0,
+    AgentFailure = 1,
+    ConfigError = 2,
+    Cancelled = 3,
+    Timeout = 4,
+    InternalError = 5,
+}

--- a/src/Andy.Cli/HeadlessConfig/HeadlessRunConfig.cs
+++ b/src/Andy.Cli/HeadlessConfig/HeadlessRunConfig.cs
@@ -1,0 +1,79 @@
+namespace Andy.Cli.HeadlessConfig;
+
+// C# model of schemas/headless-config.v1.json (AQ1, rivoli-ai/andy-cli#46).
+// JSON ↔ C# naming is handled by a SnakeCaseLower naming policy at the
+// serializer level so the schema file stays the single source of truth
+// for wire names — no per-property [JsonPropertyName] sprinkled here.
+//
+// Strict shape checks (required fields, enum closures, oneOf transport
+// variants) are enforced by JsonSchema.Net against the embedded schema
+// before this type is ever populated; records below can therefore stay
+// lenient (nullable optional fields, loose HeadlessTool discriminator).
+
+public sealed record HeadlessRunConfig
+{
+    public int SchemaVersion { get; init; }
+    public Guid RunId { get; init; }
+    public HeadlessAgent Agent { get; init; } = new();
+    public HeadlessModel Model { get; init; } = new();
+    public IReadOnlyList<HeadlessTool> Tools { get; init; } = [];
+    public HeadlessWorkspace Workspace { get; init; } = new();
+    public IReadOnlyDictionary<string, string>? EnvVars { get; init; }
+    public HeadlessOutput Output { get; init; } = new();
+    public HeadlessEventSink? EventSink { get; init; }
+    public Guid? PolicyId { get; init; }
+    public IReadOnlyList<string>? Boundaries { get; init; }
+    public HeadlessLimits Limits { get; init; } = new();
+}
+
+public sealed record HeadlessAgent
+{
+    public string Slug { get; init; } = string.Empty;
+    public int? Revision { get; init; }
+    public string Instructions { get; init; } = string.Empty;
+    public string? OutputFormat { get; init; }
+}
+
+public sealed record HeadlessModel
+{
+    public string Provider { get; init; } = string.Empty;
+    public string Id { get; init; } = string.Empty;
+    public string? ApiKeyRef { get; init; }
+}
+
+// Loose discriminated shape matching the schema's oneOf: MCP bindings carry
+// Endpoint, CLI bindings carry Binary (+ optional Command). Transport is
+// the discriminator consumers key off — schema validation has already
+// rejected any binding with the wrong combination of fields.
+public sealed record HeadlessTool
+{
+    public string Name { get; init; } = string.Empty;
+    public string Transport { get; init; } = string.Empty;
+    public string? Endpoint { get; init; }
+    public string? Binary { get; init; }
+    public IReadOnlyList<string>? Command { get; init; }
+}
+
+public sealed record HeadlessWorkspace
+{
+    public string Root { get; init; } = string.Empty;
+    public string? Branch { get; init; }
+}
+
+public sealed record HeadlessOutput
+{
+    public string File { get; init; } = string.Empty;
+    public string Stream { get; init; } = string.Empty;
+}
+
+public sealed record HeadlessEventSink
+{
+    public string? NatsSubject { get; init; }
+    public string? Path { get; init; }
+}
+
+public sealed record HeadlessLimits
+{
+    public int MaxIterations { get; init; }
+    public int TimeoutSeconds { get; init; }
+}

--- a/src/Andy.Cli/HeadlessConfig/HeadlessRunner.cs
+++ b/src/Andy.Cli/HeadlessConfig/HeadlessRunner.cs
@@ -1,0 +1,122 @@
+using System.IO;
+
+namespace Andy.Cli.HeadlessConfig;
+
+// Entry point for `andy-cli run --headless --config <path>` (AQ2,
+// rivoli-ai/andy-cli#47). Returns a HeadlessExitCode so the caller (wired
+// in Program.Main) can hand it straight to Environment.Exit.
+//
+// AQ2's job is the *scaffolding* — argument parsing, config loading, exit
+// semantics. The actual agent loop (AQ3+) is not implemented yet; a valid
+// config today is acknowledged with a diagnostic and Success, which lets
+// the Epic AP configurator exercise the full path end-to-end before AQ3
+// lands.
+public static class HeadlessRunner
+{
+    public static async Task<HeadlessExitCode> RunAsync(
+        string[] args,
+        TextWriter? stdout = null,
+        TextWriter? stderr = null,
+        CancellationToken ct = default)
+    {
+        stdout ??= Console.Out;
+        stderr ??= Console.Error;
+
+        try
+        {
+            var parsed = ParseArgs(args);
+            if (parsed.Error is not null)
+            {
+                stderr.WriteLine(parsed.Error);
+                stderr.WriteLine();
+                stderr.WriteLine(Usage);
+                return HeadlessExitCode.ConfigError;
+            }
+
+            var load = await HeadlessConfigLoader.TryLoadAsync(parsed.ConfigPath!, ct);
+            if (!load.IsSuccess)
+            {
+                stderr.WriteLine(load.Error);
+                return HeadlessExitCode.ConfigError;
+            }
+
+            // AQ3+ wires the real agent loop here. Until it lands, acknowledge the
+            // load so AP's configurator can smoke the full path.
+            var config = load.Config!;
+            stdout.WriteLine(
+                $"andy-cli run --headless: loaded config for run {config.RunId} "
+                    + $"(agent={config.Agent.Slug}, model={config.Model.Provider}:{config.Model.Id}, "
+                    + $"tools={config.Tools.Count}, limits.max_iterations={config.Limits.MaxIterations}, "
+                    + $"limits.timeout_seconds={config.Limits.TimeoutSeconds}). "
+                    + "Agent loop not yet implemented (AQ3); exiting 0.");
+            return HeadlessExitCode.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            stderr.WriteLine("andy-cli run --headless: cancelled.");
+            return HeadlessExitCode.Cancelled;
+        }
+        catch (Exception ex)
+        {
+            stderr.WriteLine(
+                $"andy-cli run --headless: internal error: {ex.GetType().Name}: {ex.Message}");
+            return HeadlessExitCode.InternalError;
+        }
+    }
+
+    private const string Usage =
+        "Usage: andy-cli run --headless --config <path>\n"
+        + "  --headless        Non-interactive execution driven entirely by the config file (required).\n"
+        + "  --config <path>   Path to a headless-config.v1 JSON file (required).";
+
+    private static ParsedArgs ParseArgs(string[] args)
+    {
+        // args[0] is guaranteed to be "run" by the dispatcher; parse the remainder.
+        var remaining = args.Length > 0 && string.Equals(args[0], "run", StringComparison.Ordinal)
+            ? args.AsSpan(1)
+            : args.AsSpan();
+
+        var headless = false;
+        string? configPath = null;
+
+        for (var i = 0; i < remaining.Length; i++)
+        {
+            var token = remaining[i];
+            switch (token)
+            {
+                case "--headless":
+                    headless = true;
+                    break;
+                case "--config":
+                    if (i + 1 >= remaining.Length)
+                    {
+                        return ParsedArgs.ErrorOnly("`--config` requires a path argument.");
+                    }
+                    configPath = remaining[++i];
+                    break;
+                default:
+                    return ParsedArgs.ErrorOnly($"Unknown argument: {token}");
+            }
+        }
+
+        if (!headless)
+        {
+            return ParsedArgs.ErrorOnly(
+                "`--headless` is required. Interactive `andy-cli run` without --headless is not supported.");
+        }
+        if (configPath is null)
+        {
+            return ParsedArgs.ErrorOnly("`--config <path>` is required.");
+        }
+
+        return new ParsedArgs { ConfigPath = configPath };
+    }
+
+    private readonly record struct ParsedArgs
+    {
+        public string? ConfigPath { get; init; }
+        public string? Error { get; init; }
+
+        public static ParsedArgs ErrorOnly(string message) => new() { Error = message };
+    }
+}

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -107,6 +107,16 @@ class Program
             return;
         }
 
+        // AQ2: `andy-cli run --headless --config <path>` — non-interactive.
+        // Handled here (not via HandleCommandLineArgs) because it needs the
+        // structured exit-code contract from rivoli-ai/andy-cli#47, which
+        // doesn't fit the ICommand Success/Fail → exit 0|1 scheme.
+        if (args.Length > 0 && args[0] == "run")
+        {
+            var exitCode = await Andy.Cli.HeadlessConfig.HeadlessRunner.RunAsync(args);
+            Environment.Exit((int)exitCode);
+        }
+
         // Check if we have command-line arguments for non-TUI commands
         if (args.Length > 0 && !args[0].StartsWith("-"))
         {

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -58,6 +58,8 @@
     <Compile Include="Integration/MultiTurnToolCallContextTests.cs" />
     <!-- AQ1 headless config schema tests (rivoli-ai/andy-cli#46) -->
     <Compile Include="HeadlessConfig/HeadlessConfigSchemaTests.cs" />
+    <!-- AQ2 headless runner tests (rivoli-ai/andy-cli#47) -->
+    <Compile Include="HeadlessConfig/HeadlessRunnerTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessRunnerTests.cs
+++ b/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessRunnerTests.cs
@@ -1,0 +1,181 @@
+// AQ2 tests (rivoli-ai/andy-cli#47). Verify the argument-parsing + config-loading
+// scaffolding for `andy-cli run --headless --config <path>`, including the
+// structured exit-code contract (0/2 paths for AQ2; 1/3/4 are AQ3+).
+//
+// The schema lives in-assembly as an embedded resource; tests share the AQ1
+// sample fixtures from schemas/samples/ to keep positive-path coverage aligned
+// with the AQ1 schema tests.
+
+using System.IO;
+using System.Text;
+using Andy.Cli.HeadlessConfig;
+using Xunit;
+
+namespace Andy.Cli.Tests.HeadlessConfig;
+
+public class HeadlessRunnerTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string SamplesDir = Path.Combine(RepoRoot, "schemas", "samples");
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Andy.Cli.sln")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is null)
+        {
+            throw new InvalidOperationException(
+                "Could not locate Andy.Cli.sln walking up from test output directory.");
+        }
+        return dir.FullName;
+    }
+
+    [Theory]
+    [InlineData("triage-headless.json")]
+    [InlineData("planning-headless.json")]
+    [InlineData("coding-headless.json")]
+    public async Task Run_ValidFixture_ReturnsSuccess(string fixtureName)
+    {
+        var path = Path.Combine(SamplesDir, fixtureName);
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless", "--config", path], stdout, stderr);
+
+        Assert.True(code == HeadlessExitCode.Success,
+            $"Expected Success, got {code}. stderr: {stderr}. stdout: {stdout}");
+        Assert.Contains("loaded config for run", stdout.ToString());
+        Assert.True(stderr.ToString().Length == 0, $"stderr should be empty but was: {stderr}");
+    }
+
+    [Fact]
+    public async Task Run_MissingHeadlessFlag_ReturnsConfigError()
+    {
+        var path = Path.Combine(SamplesDir, "triage-headless.json");
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--config", path], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+        Assert.Contains("--headless", stderr.ToString());
+    }
+
+    [Fact]
+    public async Task Run_MissingConfigFlag_ReturnsConfigError()
+    {
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless"], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+        Assert.Contains("--config", stderr.ToString());
+    }
+
+    [Fact]
+    public async Task Run_ConfigFlagWithoutValue_ReturnsConfigError()
+    {
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless", "--config"], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+        Assert.Contains("requires a path", stderr.ToString());
+    }
+
+    [Fact]
+    public async Task Run_UnknownArgument_ReturnsConfigError()
+    {
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless", "--config", "x", "--weird"], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+        Assert.Contains("Unknown argument", stderr.ToString());
+    }
+
+    [Fact]
+    public async Task Run_NonexistentConfigPath_ReturnsConfigError()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json");
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless", "--config", missing], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+        Assert.Contains("not found", stderr.ToString());
+    }
+
+    [Fact]
+    public async Task Run_MalformedJson_ReturnsConfigError()
+    {
+        using var tmp = NewTempFile();
+        File.WriteAllText(tmp.Path, "{ this is not JSON");
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless", "--config", tmp.Path], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+        Assert.Contains("not valid JSON", stderr.ToString());
+    }
+
+    [Fact]
+    public async Task Run_SchemaInvalidConfig_ReturnsConfigError()
+    {
+        // Missing every required field. Schema must reject; deserializer never sees it.
+        using var tmp = NewTempFile();
+        File.WriteAllText(tmp.Path, "{\"schema_version\": 1}");
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless", "--config", tmp.Path], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+        Assert.Contains("does not match", stderr.ToString());
+    }
+
+    [Fact]
+    public async Task Run_WrongSchemaVersion_ReturnsConfigError()
+    {
+        using var tmp = NewTempFile();
+        // Valid shape but schema_version=2; AQ1 pins v1 as `const`.
+        var validText = File.ReadAllText(Path.Combine(SamplesDir, "triage-headless.json"));
+        var bumped = validText.Replace("\"schema_version\": 1", "\"schema_version\": 2");
+        File.WriteAllText(tmp.Path, bumped);
+        var (stdout, stderr) = NewIoCapture();
+
+        var code = await HeadlessRunner.RunAsync(
+            ["run", "--headless", "--config", tmp.Path], stdout, stderr);
+
+        Assert.Equal(HeadlessExitCode.ConfigError, code);
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static (StringWriter Stdout, StringWriter Stderr) NewIoCapture()
+        => (new StringWriter(new StringBuilder()), new StringWriter(new StringBuilder()));
+
+    private static TempFile NewTempFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"aq2-{Guid.NewGuid():N}.json");
+        return new TempFile(path);
+    }
+
+    private sealed class TempFile : IDisposable
+    {
+        public string Path { get; }
+        public TempFile(string path) { Path = path; }
+        public void Dispose()
+        {
+            try { if (File.Exists(Path)) File.Delete(Path); } catch { /* best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
Closes #47.

## Summary

Adds the non-interactive headless entry point for andy-containers' configurator (Epic AP) to spawn:

```
andy-cli run --headless --config <path>
```

Flags are strict: both `--headless` and `--config <path>` are required. Anything else exits **2** (config-error).

Dispatch lives in `Program.Main` directly, separate from the existing `ICommand` switch, because the AQ2 exit-code contract (`0/1/2/3/4/5`) doesn't fit the generic `Success/Fail → exit 0|1` scheme.

### Loading path

- `HeadlessConfigLoader` reads the file, parses JSON, validates against AQ1's schema.
- Schema ships as an **embedded resource** (LogicalName: `Andy.Cli.schemas.headless-config.v1.json`) so the published binary doesn't depend on the `schemas/` directory being present alongside.
- `JsonSchema.FromText` auto-registers against the process-global `SchemaRegistry` by `$id` and throws `JsonSchemaException` on conflict. AQ1's test fixtures call `FromFile` on the same `$id`, so the loader catches + reuses the existing instance. Documented at the catch site.
- Schema-invalid / malformed JSON / missing-path: error to stderr, exit `HeadlessExitCode.ConfigError` (2). Schema errors are formatted with `EvaluationPath` + detail errors so the configurator can surface which field broke.

### Out of scope (AQ3+)

- The actual agent execution loop. For AQ2 a valid config is acknowledged with a one-line diagnostic and exits 0 — this is enough for the AP configurator to exercise the full spawn-and-capture path before AQ3 lands.
- Real handling of `Cancelled` (3) and `Timeout` (4) exit paths. The enum values are defined and the `OperationCanceledException` catch branch is wired; AQ3 populates the cancellation source.
- `AgentFailure` (1) — only reachable once AQ3's agent loop exists.

## Test plan

11 new tests in `tests/Andy.Cli.Tests/HeadlessConfig/HeadlessRunnerTests.cs`:

- [x] `Run_ValidFixture_ReturnsSuccess` — 3 theory cases across AQ1's `triage` / `planning` / `coding` sample fixtures.
- [x] `Run_MissingHeadlessFlag_ReturnsConfigError`
- [x] `Run_MissingConfigFlag_ReturnsConfigError`
- [x] `Run_ConfigFlagWithoutValue_ReturnsConfigError`
- [x] `Run_UnknownArgument_ReturnsConfigError`
- [x] `Run_NonexistentConfigPath_ReturnsConfigError`
- [x] `Run_MalformedJson_ReturnsConfigError`
- [x] `Run_SchemaInvalidConfig_ReturnsConfigError`
- [x] `Run_WrongSchemaVersion_ReturnsConfigError`
- [x] Whole `Andy.Cli.Tests` suite: **251 passed / 1 skipped / 0 failed** (no regressions from the `Program.Main` dispatch change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)