### PR TITLE
Bump Andy.Llm to 2026.4.26-rc.29 — provider-error propagation fix

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Andy.Acp.Core" Version="2025.11.18-rc.3" />
     <PackageReference Include="Andy.Engine" Version="2026.2.10-rc.28" />
-    <PackageReference Include="Andy.Llm" Version="2025.11.19-rc.24" />
+    <PackageReference Include="Andy.Llm" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
     <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />


### PR DESCRIPTION
## Summary

Picks up rivoli-ai/andy-llm#5 — `CerebrasProvider`, `ChatCompletionsStrategy`, and `ResponsesApiStrategy` now throw `InvalidOperationException` on HTTP/SDK failures instead of synthesising fake `LlmResponse`s with the error string in `Content` and `FinishReason="error"`. AQ3's existing `!result.Success` branch (in `HeadlessAgentRunner`) fires correctly on transport errors instead of writing them to the output file as if they were the agent's answer.

## Empirical verification

Re-ran the same AQ3 smoke config (empty tools, simple instructions) against Cerebras, which is currently HTTP 402 on quota. Same code in `andy-cli`, only `Andy.Llm` changed:

**Before (`Andy.Llm 2025.11.19-rc.24`):**
```
{"kind":"output_written","data":{"path":"/tmp/aq3-smoke/output.txt","bytes":75}}
{"kind":"finished","data":{"exit_code":0,"duration_ms":588,"iterations":1}}
$ cat /tmp/aq3-smoke/output.txt
Cerebras API error: Service request failed.
Status: 402 (Payment Required)
$ echo $?
0
```
A 402 was getting written to the agent's output file as if the model had produced it, with `exit_code=0`.

**After (`Andy.Llm 2026.4.26-rc.29`):**
```
{"kind":"error","data":{"message":"Agent loop did not converge: error: Cerebras request failed (status 402): ...","fatal":true}}
{"kind":"finished","data":{"exit_code":1,"duration_ms":898,"iterations":1}}
$ ls /tmp/aq3-smoke/output.txt
ls: /tmp/aq3-smoke/output.txt: No such file or directory
$ echo $?
1
```
Structured `error` event with `fatal: true`, `finished` with `exit_code=1`, output file not written, process exit 1.

## Test plan

- [x] `dotnet build` clean.
- [x] AQ3 smoke against Cerebras (402 quota): exit 1 + structured error event + no output file (transcript above).
- [x] AQ3 smoke against OpenAI `gpt-4o-mini` from earlier in the session: still exit 0 with `DONE` written to the output file (success path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)