### PR TITLE
Transparent UI backgrounds with opaque overlays

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
     <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />
-    <PackageReference Include="Andy.Tui" Version="2025.10.24-rc.39" />
+    <PackageReference Include="Andy.Tui" Version="2026.5.29-rc.43" />
     <PackageReference Include="JsonRepairSharp" Version="1.2.3" />
     <PackageReference Include="JsonSchema.Net" Version="9.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -135,8 +135,10 @@ class Program
         var pty = new LocalStdoutPty();
         Console.Write("\u001b[?1049h\u001b[?25l\u001b[?7l");
 
-        // Set console background to black after entering alternate screen
-        Console.BackgroundColor = ConsoleColor.Black;
+        // Use the terminal's own background (do not force black) so a transparent
+        // or themed terminal shows through the UI. ESC[49m resets to the default bg.
+        Console.ResetColor();
+        Console.Write("[49m");
         Console.Clear();
 
         try
@@ -641,7 +643,7 @@ class Program
                     var confirmB = new DL.DisplayListBuilder();
                     confirmB.PushClip(new DL.ClipPush(0, 0, viewport.Width, viewport.Height));
 
-                    // Semi-transparent backdrop
+                    // Opaque backdrop: occlude the content behind the modal dialog.
                     confirmB.DrawRect(new DL.Rect(0, 0, viewport.Width, viewport.Height, new DL.Rgb24(0, 0, 0)));
 
                     // Dialog box
@@ -1320,17 +1322,23 @@ class Program
                     tokenCounter.RenderAt(tokenCounterX, viewport.Height - 1, baseDl, wb);
                 }
 
-                // Render command palette (if open)
-                commandPalette.Render(new L.Rect(0, 0, viewport.Width, viewport.Height), baseDl, wb);
+                // Render command palette (if open) into a SEPARATE builder. Overlays
+                // must occlude the content behind them, so they keep their own
+                // (opaque) background instead of being made transparent like the
+                // main surface — otherwise the feed bleeds through the palette.
+                var overlayB = new DL.DisplayListBuilder();
+                commandPalette.Render(new L.Rect(0, 0, viewport.Width, viewport.Height), baseDl, overlayB);
 
                 var overlay = new DL.DisplayListBuilder();
                 hud.ViewportCols = viewport.Width; hud.ViewportRows = viewport.Height;
                 hud.Contribute(baseDl, overlay);
-                // Simple combine logic
+                // Combine: main surface is rendered transparent (Append strips
+                // backgrounds); overlays are rendered opaque (AppendOpaque keeps them).
                 var builder = new DL.DisplayListBuilder();
                 foreach (var op in baseDl.Ops) Append(op, builder);
                 foreach (var op in wb.Build().Ops) Append(op, builder);
-                foreach (var op in overlay.Build().Ops) Append(op, builder);
+                foreach (var op in overlayB.Build().Ops) AppendOpaque(op, builder);
+                foreach (var op in overlay.Build().Ops) AppendOpaque(op, builder);
                 await scheduler.RenderOnceAsync(builder.Build(), viewport, caps, pty, CancellationToken.None);
                 // Position terminal cursor as a block inside the prompt (only when not processing)
                 // NOTE: We're using direct Console.Write here instead of going through the TUI library (PTY).
@@ -1358,7 +1366,25 @@ class Program
                     }
                 }
 
+                // Main surface: transparent. Drop any fill/bg a widget hardcoded so the
+                // terminal background shows through the UI (e.g. message blocks that bake
+                // in a black background).
                 static void Append(object op, DL.DisplayListBuilder b)
+                {
+                    switch (op)
+                    {
+                        case DL.Rect r: b.DrawRect(r with { Fill = null }); break;
+                        case DL.Border br: b.DrawBorder(br); break;
+                        case DL.TextRun tr: b.DrawText(tr with { Bg = null }); break;
+                        case DL.ClipPush cp: b.PushClip(cp); break;
+                        case DL.LayerPush lp: b.PushLayer(lp); break;
+                        case DL.Pop: b.Pop(); break;
+                    }
+                }
+
+                // Overlays (command palette, menus): keep their own opaque background so
+                // they occlude the content behind them and stay readable.
+                static void AppendOpaque(object op, DL.DisplayListBuilder b)
                 {
                     switch (op)
                     {

--- a/src/Andy.Cli/Themes/Theme.cs
+++ b/src/Andy.Cli/Themes/Theme.cs
@@ -7,12 +7,15 @@ namespace Andy.Cli.Themes
     /// </summary>
     public sealed class Theme
     {
-        // Background colors
-        public DL.Rgb24 Background { get; set; } = new DL.Rgb24(0, 0, 0);
-        public DL.Rgb24 HeaderBackground { get; set; } = new DL.Rgb24(30, 35, 50);
-        public DL.Rgb24 DialogBackground { get; set; } = new DL.Rgb24(30, 30, 40);
+        // Background colors.
+        // null = transparent: the terminal's own background (including transparency)
+        // shows through. Main surface, header, prompt and dialog backgrounds are
+        // transparent; the remaining chrome keeps a subtle shade for legibility.
+        public DL.Rgb24? Background { get; set; } = null;
+        public DL.Rgb24? HeaderBackground { get; set; } = null;
+        public DL.Rgb24? DialogBackground { get; set; } = null;
         public DL.Rgb24 CodeBlockBackground { get; set; } = new DL.Rgb24(20, 20, 30);
-        public DL.Rgb24 PromptBackground { get; set; } = new DL.Rgb24(0, 0, 0);
+        public DL.Rgb24? PromptBackground { get; set; } = null;
         public DL.Rgb24 ToastBackground { get; set; } = new DL.Rgb24(60, 60, 20);
         public DL.Rgb24 StatusLineBackground { get; set; } = new DL.Rgb24(10, 10, 10);
         public DL.Rgb24 KeyHintsBackground { get; set; } = new DL.Rgb24(15, 15, 15);


### PR DESCRIPTION
## Summary
Makes the main chat surface transparent so the terminal's own background (a translucent window or custom theme) shows through, while keeping overlays opaque so they stay readable.

## Changes
- Bump `Andy.Tui` to `2026.5.29-rc.43` (adds transparent/null backgrounds).
- **Theme**: `Background`, `HeaderBackground`, `PromptBackground`, `DialogBackground` are nullable and default to transparent.
- Remove the forced black console background; reset to the terminal default (`ESC[49m`).
- **Main frame** assembly strips any hardcoded fill/bg (`Append`) so message blocks that baked in a black background render transparent.
- **Overlays** (command palette, modal confirm dialog) keep their opaque background via `AppendOpaque` so they occlude content behind them (fixes the palette showing feed text bleeding through).

## Notes
- Known follow-up: stale left-margin residue from prior output (unmanaged cells unmasked by transparency) — tracked separately; not a newline bug (verified by tests in andy-tui2).