### PR TITLE
Clear stale margin residue on content reflow

### DIFF
--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -147,6 +147,7 @@ class Program
 
             // Scroll mode state
             ScrollMode scrollMode = ScrollMode.Feed;
+            int lastReflowSig = int.MinValue; // forces a full clear+repaint on the first frame
             var promptHistory = new List<string>(); // Store user prompts for history navigation
             int historyIndex = -1; // -1 means not navigating history, showing current input
 
@@ -1339,6 +1340,23 @@ class Program
                 foreach (var op in wb.Build().Ops) Append(op, builder);
                 foreach (var op in overlayB.Build().Ops) AppendOpaque(op, builder);
                 foreach (var op in overlay.Build().Ops) AppendOpaque(op, builder);
+
+                // The renderer only repaints cells it draws, so with transparent
+                // backgrounds the unmanaged left margin / gap rows can reveal stale
+                // "prior output" left in the terminal. Whenever feed content reflows
+                // (items added/removed, line count or scroll change), force the next
+                // frame to be a full clear + repaint (ESC[2J) so that residue is wiped.
+                // (Scroll offset is intentionally excluded: scrolling only changes the
+                // diff-managed feed area, not the margin, so it needs no full repaint.)
+                int reflowSig = HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, (int)scrollMode);
+                if (reflowSig != lastReflowSig)
+                {
+                    lastReflowSig = reflowSig;
+                    // FrameScheduler has no "reset" hook; a fresh instance has no previous
+                    // grid, so its next render emits a full clear + complete repaint.
+                    scheduler = new Andy.Tui.Core.FrameScheduler(targetFps: 30);
+                    scheduler.SetMetricsSink(hud);
+                }
                 await scheduler.RenderOnceAsync(builder.Build(), viewport, caps, pty, CancellationToken.None);
                 // Position terminal cursor as a block inside the prompt (only when not processing)
                 // NOTE: We're using direct Console.Write here instead of going through the TUI library (PTY).

--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -411,6 +411,12 @@ namespace Andy.Cli.Widgets
             if (_animRemaining > 0) _animRemaining = Math.Max(0, _animRemaining - _animSpeed);
         }
 
+        /// <summary>Number of feed items. Changes when content is added/removed/cleared.</summary>
+        public int ItemCount { get { lock (_itemsLock) { return _items.Count; } } }
+
+        /// <summary>Total wrapped line count from the last <see cref="Render"/> (content reflow signal).</summary>
+        public int RenderedLineCount => _totalLinesCache;
+
         private int _totalLinesCache;
 
         /// <summary>Render feed items inside rect, stacking vertically with bottom alignment when following tail.</summary>

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Andy.Llm" Version="2025.11.19-rc.24" />
+    <PackageReference Include="Andy.Llm" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
@@ -48,6 +48,8 @@
     <Compile Include="Widgets/TokenCounterTests.cs" />
     <!-- KeyHintsBar tests -->
     <Compile Include="Widgets/KeyHintsBarTests.cs" />
+    <!-- FeedView reflow signal tests (margin residue fix) -->
+    <Compile Include="Widgets/FeedViewReflowSignalTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
     <!-- Parallel tool execution tests -->

--- a/tests/Andy.Cli.Tests/Widgets/FeedViewReflowSignalTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/FeedViewReflowSignalTests.cs
@@ -1,0 +1,134 @@
+using Andy.Cli.Widgets;
+using Xunit;
+using DL = Andy.Tui.DisplayList;
+using L = Andy.Tui.Layout;
+
+namespace Andy.Cli.Tests.Widgets;
+
+/// <summary>
+/// Tests for the reflow signals (<see cref="FeedView.ItemCount"/> and
+/// <see cref="FeedView.RenderedLineCount"/>) that Program.cs combines into a
+/// reflow signature to force a full clear+repaint, wiping stale margin residue
+/// left behind by transparent backgrounds. See commit "Clear stale margin
+/// residue on content reflow".
+/// </summary>
+public class FeedViewReflowSignalTests
+{
+    private static (DL.DisplayList baseDl, DL.DisplayListBuilder builder) NewRenderContext()
+    {
+        var baseDl = new DL.DisplayListBuilder().Build();
+        var builder = new DL.DisplayListBuilder();
+        return (baseDl, builder);
+    }
+
+    private static void Render(FeedView feed, int width = 80, int height = 24)
+    {
+        var (baseDl, builder) = NewRenderContext();
+        feed.Render(new L.Rect(2, 3, width, height), baseDl, builder);
+    }
+
+    [Fact]
+    public void ItemCount_StartsAtZero()
+    {
+        var feed = new FeedView();
+        Assert.Equal(0, feed.ItemCount);
+    }
+
+    [Fact]
+    public void ItemCount_TracksAddedItems()
+    {
+        var feed = new FeedView();
+
+        feed.AddMarkdown("first");
+        Assert.Equal(1, feed.ItemCount);
+
+        feed.AddMarkdown("second");
+        feed.AddMarkdown("third");
+        Assert.Equal(3, feed.ItemCount);
+    }
+
+    [Fact]
+    public void ItemCount_ResetsToZeroAfterClear()
+    {
+        var feed = new FeedView();
+        feed.AddMarkdown("a");
+        feed.AddMarkdown("b");
+        Assert.Equal(2, feed.ItemCount);
+
+        feed.Clear();
+        Assert.Equal(0, feed.ItemCount);
+    }
+
+    [Fact]
+    public void RenderedLineCount_IsZeroBeforeFirstRender()
+    {
+        var feed = new FeedView();
+        feed.AddMarkdown("content that has not been rendered yet");
+
+        // RenderedLineCount reflects the *last render*, so it stays zero until Render runs.
+        Assert.Equal(0, feed.RenderedLineCount);
+    }
+
+    [Fact]
+    public void RenderedLineCount_IsPositiveAfterRenderingContent()
+    {
+        var feed = new FeedView();
+        feed.AddMarkdown("line one\nline two\nline three");
+
+        Render(feed);
+
+        Assert.True(feed.RenderedLineCount > 0,
+            $"Expected rendered lines for non-empty content, got {feed.RenderedLineCount}");
+    }
+
+    [Fact]
+    public void RenderedLineCount_GrowsWhenMoreContentIsAdded()
+    {
+        var feed = new FeedView();
+        feed.AddMarkdown("single line");
+        Render(feed);
+        int afterFirst = feed.RenderedLineCount;
+
+        feed.AddMarkdown("another\nblock\nof\nseveral\nlines");
+        Render(feed);
+        int afterSecond = feed.RenderedLineCount;
+
+        Assert.True(afterSecond > afterFirst,
+            $"Expected line count to grow on reflow: {afterFirst} -> {afterSecond}");
+    }
+
+    [Fact]
+    public void RenderedLineCount_ReflectsMultiLineContent()
+    {
+        // A markdown item maps one input line to one rendered row, so RenderedLineCount
+        // grows with the number of content lines — the reflow signal Program.cs relies on.
+        var single = new FeedView();
+        single.AddMarkdown("one");
+        Render(single);
+        int singleLines = single.RenderedLineCount;
+
+        var multi = new FeedView();
+        multi.AddMarkdown("one\ntwo\nthree\nfour");
+        Render(multi);
+        int multiLines = multi.RenderedLineCount;
+
+        Assert.True(multiLines > singleLines,
+            $"Expected more rows for multi-line content: single={singleLines}, multi={multiLines}");
+    }
+
+    [Fact]
+    public void ReflowSignature_ChangesWhenContentChanges()
+    {
+        // Mirrors the signature Program.cs builds: HashCode.Combine(ItemCount, RenderedLineCount, scrollMode).
+        // A different signature is what triggers the full clear+repaint that wipes margin residue.
+        var feed = new FeedView();
+        Render(feed);
+        int empty = System.HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, 0);
+
+        feed.AddMarkdown("now there is content");
+        Render(feed);
+        int withContent = System.HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, 0);
+
+        Assert.NotEqual(empty, withContent);
+    }
+}


### PR DESCRIPTION
## Problem
With transparent backgrounds (PR #61), the renderer no longer paints an opaque fill over the whole screen. Cells the TUI never draws — the left-margin columns and gap rows — can therefore reveal stale "prior output" already in the terminal (the `• n` / `• now:` fragments). The per-cell frame diff only repaints cells the TUI itself drew, so that residue was never cleared.

Note: this is **not** a newline-processing bug — the MarkdownRenderer normalizes newlines consistently and never draws outside its rect (verified by tests added in andy-tui2).

## Fix
Force a full clear + repaint whenever feed content reflows. A fresh `FrameScheduler` has no previous grid, so its next frame emits `ESC[2J` followed by a complete repaint, wiping any residue. The trigger is a signature of `(feed.ItemCount, feed.RenderedLineCount, scrollMode)`.

- Scrolling is intentionally excluded (it only changes the diff-managed feed area, not the margin), so there's no per-scroll-step flicker.
- Adds `FeedView.ItemCount` and `FeedView.RenderedLineCount` as the reflow signals.

## Verification needed
This affects live rendering, which I can't observe headlessly. Please run andy-cli and confirm:
1. The left-margin `• n` residue is gone after running commands (`/tools`, `/help`, chatting).
2. No objectionable full-screen flicker when a new message/response appears (a brief clear on each new feed item is expected).