### PR TITLE
AQ8: headless contract validation library

### DIFF
--- a/Andy.Cli.sln
+++ b/Andy.Cli.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Andy.Cli.Tests", "tests\Andy.Cli.Tests\Andy.Cli.Tests.csproj", "{CDDC1F3D-F93C-408A-87CB-4186E3AB3094}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Andy.Cli.Headless.Contract", "src\Andy.Cli.Headless.Contract\Andy.Cli.Headless.Contract.csproj", "{FF501CA8-B643-45A9-A720-5D424D3A4C65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,18 @@ Global
 		{CDDC1F3D-F93C-408A-87CB-4186E3AB3094}.Release|x64.Build.0 = Release|Any CPU
 		{CDDC1F3D-F93C-408A-87CB-4186E3AB3094}.Release|x86.ActiveCfg = Release|Any CPU
 		{CDDC1F3D-F93C-408A-87CB-4186E3AB3094}.Release|x86.Build.0 = Release|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Debug|x64.Build.0 = Debug|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Debug|x86.Build.0 = Debug|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Release|x64.ActiveCfg = Release|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Release|x64.Build.0 = Release|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Release|x86.ActiveCfg = Release|Any CPU
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,5 +66,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F1DF3590-7D70-4F8D-B39B-E87B85115DCE} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{CDDC1F3D-F93C-408A-87CB-4186E3AB3094} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{FF501CA8-B643-45A9-A720-5D424D3A4C65} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/Andy.Cli.Headless.Contract/Andy.Cli.Headless.Contract.csproj
+++ b/src/Andy.Cli.Headless.Contract/Andy.Cli.Headless.Contract.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <IsPackable>true</IsPackable>
+    <PackageId>Andy.Cli.Headless.Contract</PackageId>
+    <Version>2026.5.29-rc.1</Version>
+    <Authors>Rivoli AI</Authors>
+    <Company>Rivoli AI</Company>
+    <Description>Contract validation for the andy-cli headless run configuration and event-stream schemas. Lets generators (andy-containers, conductor) verify their produced headless config against the canonical JSON schema, with pass/fail results and error messages.</Description>
+    <PackageTags>andy-cli;headless;json-schema;contract;validation</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Single source of truth: link the canonical schemas as embedded resources. -->
+    <EmbeddedResource Include="..\..\schemas\headless-config.v1.json">
+      <LogicalName>Andy.Cli.Headless.Contract.headless-config.v1.json</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\..\schemas\headless-events.v1.json">
+      <LogicalName>Andy.Cli.Headless.Contract.headless-events.v1.json</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JsonSchema.Net" Version="7.3.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/Andy.Cli.Headless.Contract/Andy.Cli.Headless.Contract.csproj
+++ b/src/Andy.Cli.Headless.Contract/Andy.Cli.Headless.Contract.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="7.3.4" />
+    <PackageReference Include="JsonSchema.Net" Version="9.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Andy.Cli.Headless.Contract/HeadlessConfigContract.cs
+++ b/src/Andy.Cli.Headless.Contract/HeadlessConfigContract.cs
@@ -29,8 +29,12 @@ public static class HeadlessConfigContract
 
     private static readonly Lazy<string> ConfigSchemaTextLazy = new(() => ReadEmbeddedResource(ConfigSchemaResource));
     private static readonly Lazy<string> EventSchemaTextLazy = new(() => ReadEmbeddedResource(EventSchemaResource));
-    private static readonly Lazy<JsonSchema> ConfigSchemaLazy = new(() => JsonSchema.FromText(ConfigSchemaTextLazy.Value));
-    private static readonly Lazy<JsonSchema> EventSchemaLazy = new(() => JsonSchema.FromText(EventSchemaTextLazy.Value));
+    private static readonly Lazy<JsonSchema> ConfigSchemaLazy = new(() => ParseSchema(ConfigSchemaTextLazy.Value));
+    private static readonly Lazy<JsonSchema> EventSchemaLazy = new(() => ParseSchema(EventSchemaTextLazy.Value));
+
+    private static JsonSchema ParseSchema(string text)
+        => JsonSerializer.Deserialize<JsonSchema>(text)
+            ?? throw new InvalidOperationException("Embedded schema text deserialized to null.");
 
     /// <summary>
     /// Gets the raw JSON text of the embedded headless configuration schema.
@@ -97,35 +101,26 @@ public static class HeadlessConfigContract
             throw new ArgumentNullException(nameof(json));
         }
 
-        JsonNode? instance;
+        JsonDocument document;
         try
         {
-            instance = JsonNode.Parse(json);
+            document = JsonDocument.Parse(json);
         }
         catch (JsonException ex)
         {
             return ValidationResult.Failure(new[] { $"Invalid JSON: {ex.Message}" });
         }
 
-        return Evaluate(instance, schema);
+        using (document)
+        {
+            return Evaluate(document.RootElement, schema);
+        }
     }
 
     private static ValidationResult ValidateElement(JsonElement element, JsonSchema schema)
-    {
-        JsonNode? instance;
-        try
-        {
-            instance = JsonNode.Parse(element.GetRawText());
-        }
-        catch (JsonException ex)
-        {
-            return ValidationResult.Failure(new[] { $"Invalid JSON: {ex.Message}" });
-        }
+        => Evaluate(element, schema);
 
-        return Evaluate(instance, schema);
-    }
-
-    private static ValidationResult Evaluate(JsonNode? instance, JsonSchema schema)
+    private static ValidationResult Evaluate(JsonElement instance, JsonSchema schema)
     {
         var options = new EvaluationOptions { OutputFormat = OutputFormat.List };
         var results = schema.Evaluate(instance, options);
@@ -152,7 +147,7 @@ public static class HeadlessConfigContract
 
     private static void Walk(EvaluationResults node, List<string> messages)
     {
-        if (!node.IsValid && node.HasErrors && node.Errors is not null)
+        if (!node.IsValid && node.Errors is { Count: > 0 })
         {
             var location = node.InstanceLocation.ToString();
             location = string.IsNullOrEmpty(location) ? "(root)" : location;
@@ -162,9 +157,12 @@ public static class HeadlessConfigContract
             }
         }
 
-        foreach (var child in node.Details)
+        if (node.Details is not null)
         {
-            Walk(child, messages);
+            foreach (var child in node.Details)
+            {
+                Walk(child, messages);
+            }
         }
     }
 

--- a/src/Andy.Cli.Headless.Contract/HeadlessConfigContract.cs
+++ b/src/Andy.Cli.Headless.Contract/HeadlessConfigContract.cs
@@ -1,0 +1,180 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+
+namespace Andy.Cli.Headless.Contract;
+
+/// <summary>
+/// Validates headless run configurations and event-stream records against the
+/// canonical Andy CLI headless JSON schemas.
+/// </summary>
+/// <remarks>
+/// Generators such as andy-containers and conductor can call
+/// <see cref="ValidateConfig(string)"/> to confirm a produced configuration matches
+/// the contract before launching <c>andy-cli run --headless</c>, without depending on
+/// the full CLI. The schemas are embedded in this assembly so there is a single
+/// source of truth shared with the repository's <c>schemas/</c> directory.
+/// </remarks>
+public static class HeadlessConfigContract
+{
+    /// <summary>
+    /// The schema version this contract validates. Matches the required
+    /// <c>version</c> constant in the configuration schema.
+    /// </summary>
+    public const int SchemaVersion = 1;
+
+    private const string ConfigSchemaResource = "Andy.Cli.Headless.Contract.headless-config.v1.json";
+    private const string EventSchemaResource = "Andy.Cli.Headless.Contract.headless-events.v1.json";
+
+    private static readonly Lazy<string> ConfigSchemaTextLazy = new(() => ReadEmbeddedResource(ConfigSchemaResource));
+    private static readonly Lazy<string> EventSchemaTextLazy = new(() => ReadEmbeddedResource(EventSchemaResource));
+    private static readonly Lazy<JsonSchema> ConfigSchemaLazy = new(() => JsonSchema.FromText(ConfigSchemaTextLazy.Value));
+    private static readonly Lazy<JsonSchema> EventSchemaLazy = new(() => JsonSchema.FromText(EventSchemaTextLazy.Value));
+
+    /// <summary>
+    /// Gets the raw JSON text of the embedded headless configuration schema.
+    /// </summary>
+    /// <returns>The configuration schema document as JSON text.</returns>
+    public static string GetConfigSchemaText() => ConfigSchemaTextLazy.Value;
+
+    /// <summary>
+    /// Gets the raw JSON text of the embedded headless event-stream schema.
+    /// </summary>
+    /// <returns>The event schema document as JSON text.</returns>
+    public static string GetEventSchemaText() => EventSchemaTextLazy.Value;
+
+    /// <summary>
+    /// Validates a headless configuration document supplied as JSON text.
+    /// </summary>
+    /// <param name="json">The configuration document, serialized as JSON.</param>
+    /// <returns>
+    /// A <see cref="ValidationResult"/> indicating whether the document satisfies the
+    /// configuration schema, along with any error messages.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="json"/> is <c>null</c>.</exception>
+    public static ValidationResult ValidateConfig(string json)
+        => ValidateText(json, ConfigSchemaLazy.Value);
+
+    /// <summary>
+    /// Validates a headless configuration document supplied as a <see cref="JsonElement"/>.
+    /// </summary>
+    /// <param name="config">The configuration document.</param>
+    /// <returns>
+    /// A <see cref="ValidationResult"/> indicating whether the document satisfies the
+    /// configuration schema, along with any error messages.
+    /// </returns>
+    public static ValidationResult ValidateConfig(JsonElement config)
+        => ValidateElement(config, ConfigSchemaLazy.Value);
+
+    /// <summary>
+    /// Validates a single headless event record supplied as JSON text.
+    /// </summary>
+    /// <param name="json">The event record, serialized as JSON.</param>
+    /// <returns>
+    /// A <see cref="ValidationResult"/> indicating whether the record satisfies the
+    /// event schema, along with any error messages.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="json"/> is <c>null</c>.</exception>
+    public static ValidationResult ValidateEvent(string json)
+        => ValidateText(json, EventSchemaLazy.Value);
+
+    /// <summary>
+    /// Validates a single headless event record supplied as a <see cref="JsonElement"/>.
+    /// </summary>
+    /// <param name="evt">The event record.</param>
+    /// <returns>
+    /// A <see cref="ValidationResult"/> indicating whether the record satisfies the
+    /// event schema, along with any error messages.
+    /// </returns>
+    public static ValidationResult ValidateEvent(JsonElement evt)
+        => ValidateElement(evt, EventSchemaLazy.Value);
+
+    private static ValidationResult ValidateText(string json, JsonSchema schema)
+    {
+        if (json is null)
+        {
+            throw new ArgumentNullException(nameof(json));
+        }
+
+        JsonNode? instance;
+        try
+        {
+            instance = JsonNode.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            return ValidationResult.Failure(new[] { $"Invalid JSON: {ex.Message}" });
+        }
+
+        return Evaluate(instance, schema);
+    }
+
+    private static ValidationResult ValidateElement(JsonElement element, JsonSchema schema)
+    {
+        JsonNode? instance;
+        try
+        {
+            instance = JsonNode.Parse(element.GetRawText());
+        }
+        catch (JsonException ex)
+        {
+            return ValidationResult.Failure(new[] { $"Invalid JSON: {ex.Message}" });
+        }
+
+        return Evaluate(instance, schema);
+    }
+
+    private static ValidationResult Evaluate(JsonNode? instance, JsonSchema schema)
+    {
+        var options = new EvaluationOptions { OutputFormat = OutputFormat.List };
+        var results = schema.Evaluate(instance, options);
+        if (results.IsValid)
+        {
+            return ValidationResult.Success();
+        }
+
+        var errors = CollectErrors(results);
+        if (errors.Count == 0)
+        {
+            errors.Add("Document did not match the schema.");
+        }
+
+        return ValidationResult.Failure(errors);
+    }
+
+    private static List<string> CollectErrors(EvaluationResults results)
+    {
+        var messages = new List<string>();
+        Walk(results, messages);
+        return messages;
+    }
+
+    private static void Walk(EvaluationResults node, List<string> messages)
+    {
+        if (!node.IsValid && node.HasErrors && node.Errors is not null)
+        {
+            var location = node.InstanceLocation.ToString();
+            location = string.IsNullOrEmpty(location) ? "(root)" : location;
+            foreach (var error in node.Errors)
+            {
+                messages.Add($"{location}: {error.Value}");
+            }
+        }
+
+        foreach (var child in node.Details)
+        {
+            Walk(child, messages);
+        }
+    }
+
+    private static string ReadEmbeddedResource(string resourceName)
+    {
+        var assembly = typeof(HeadlessConfigContract).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded schema resource '{resourceName}' was not found in assembly '{assembly.FullName}'.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Andy.Cli.Headless.Contract/ValidationResult.cs
+++ b/src/Andy.Cli.Headless.Contract/ValidationResult.cs
@@ -1,0 +1,41 @@
+namespace Andy.Cli.Headless.Contract;
+
+/// <summary>
+/// Outcome of validating a JSON document against a headless contract schema.
+/// </summary>
+public sealed class ValidationResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationResult"/> class.
+    /// </summary>
+    /// <param name="isValid">Whether the document satisfied the schema.</param>
+    /// <param name="errors">Human-readable validation error messages. Empty when valid.</param>
+    public ValidationResult(bool isValid, IReadOnlyList<string> errors)
+    {
+        IsValid = isValid;
+        Errors = errors ?? Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the document satisfied the schema.
+    /// </summary>
+    public bool IsValid { get; }
+
+    /// <summary>
+    /// Gets the validation error messages. Empty when <see cref="IsValid"/> is <c>true</c>.
+    /// </summary>
+    public IReadOnlyList<string> Errors { get; }
+
+    /// <summary>
+    /// Creates a successful (valid) result with no errors.
+    /// </summary>
+    /// <returns>A valid <see cref="ValidationResult"/>.</returns>
+    public static ValidationResult Success() => new(true, Array.Empty<string>());
+
+    /// <summary>
+    /// Creates a failed (invalid) result carrying the supplied error messages.
+    /// </summary>
+    /// <param name="errors">One or more validation error messages.</param>
+    /// <returns>An invalid <see cref="ValidationResult"/>.</returns>
+    public static ValidationResult Failure(IReadOnlyList<string> errors) => new(false, errors);
+}

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Andy.Cli\Andy.Cli.csproj" />
+    <ProjectReference Include="..\..\src\Andy.Cli.Headless.Contract\Andy.Cli.Headless.Contract.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,6 +65,8 @@
     <Compile Include="HeadlessConfig/HeadlessRunnerTests.cs" />
     <!-- Headless provider/model resolution (OpenRouter) -->
     <Compile Include="HeadlessConfig/HeadlessProviderModelTests.cs" />
+    <!-- AQ8 headless contract validation library (rivoli-ai/andy-cli#54) -->
+    <Compile Include="HeadlessConfig/HeadlessConfigContractTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigContractTests.cs
+++ b/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigContractTests.cs
@@ -5,7 +5,9 @@ using Xunit;
 namespace Andy.Cli.Tests.HeadlessConfig;
 
 /// <summary>
-/// Verifies the public contract-validation surface used by external generators.
+/// Verifies the public contract-validation surface used by external generators
+/// (andy-containers, conductor) to check their produced headless config against
+/// the canonical schema. Field names mirror schemas/headless-config.v1.json.
 /// </summary>
 public class HeadlessConfigContractTests
 {
@@ -20,6 +22,26 @@ public class HeadlessConfigContractTests
         }
         return dir ?? throw new InvalidOperationException("Could not locate repository root.");
     }
+
+    // A configuration that satisfies headless-config.v1.json in full.
+    private const string ValidConfigJson = """
+    {
+      "schema_version": 1,
+      "run_id": "00000000-0000-0000-0000-0000000000ff",
+      "agent": {
+        "slug": "triage-agent",
+        "instructions": "Classify issues."
+      },
+      "model": {
+        "provider": "anthropic",
+        "id": "claude-sonnet-4-6"
+      },
+      "tools": [],
+      "workspace": { "root": "/workspace" },
+      "output": { "file": "/tmp/out.json", "stream": "stdout" },
+      "limits": { "max_iterations": 50, "timeout_seconds": 300 }
+    }
+    """;
 
     [Fact]
     public void SchemaVersion_Is_One()
@@ -40,6 +62,15 @@ public class HeadlessConfigContractTests
     }
 
     [Fact]
+    public void ValidateConfig_InlineValidConfig_Passes()
+    {
+        var result = HeadlessConfigContract.ValidateConfig(ValidConfigJson);
+
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void ValidateConfig_JsonElementOverload_Passes()
     {
         var samplePath = Path.Combine(RepoRoot, "schemas", "samples", "planning-headless.json");
@@ -53,14 +84,8 @@ public class HeadlessConfigContractTests
     [Fact]
     public void ValidateConfig_UnknownProvider_Fails()
     {
-        const string json = """
-        {
-          "version": 1,
-          "agent": { "name": "planner" },
-          "provider": { "name": "cohere" },
-          "task": { "prompt": "hello" }
-        }
-        """;
+        // model.provider enum is closed; "cohere" is not a member.
+        var json = ValidConfigJson.Replace("\"provider\": \"anthropic\"", "\"provider\": \"cohere\"");
 
         var result = HeadlessConfigContract.ValidateConfig(json);
 
@@ -71,12 +96,16 @@ public class HeadlessConfigContractTests
     [Fact]
     public void ValidateConfig_MissingRequiredField_Fails()
     {
-        // Missing the required "task" object.
+        // Drop the required top-level "limits" object.
         const string json = """
         {
-          "version": 1,
-          "agent": { "name": "planner" },
-          "provider": { "name": "openai" }
+          "schema_version": 1,
+          "run_id": "00000000-0000-0000-0000-0000000000ff",
+          "agent": { "slug": "triage-agent", "instructions": "Classify issues." },
+          "model": { "provider": "anthropic", "id": "claude-sonnet-4-6" },
+          "tools": [],
+          "workspace": { "root": "/workspace" },
+          "output": { "file": "/tmp/out.json", "stream": "stdout" }
         }
         """;
 
@@ -89,14 +118,8 @@ public class HeadlessConfigContractTests
     [Fact]
     public void ValidateConfig_WrongVersionConstant_Fails()
     {
-        const string json = """
-        {
-          "version": 2,
-          "agent": { "name": "planner" },
-          "provider": { "name": "openai" },
-          "task": { "prompt": "hello" }
-        }
-        """;
+        // schema_version is a const: 1.
+        var json = ValidConfigJson.Replace("\"schema_version\": 1", "\"schema_version\": 2");
 
         var result = HeadlessConfigContract.ValidateConfig(json);
 
@@ -122,11 +145,19 @@ public class HeadlessConfigContractTests
     [Fact]
     public void ValidateEvent_ValidRecord_Passes()
     {
+        // Envelope per headless-events.v1.json: schema_version, ts, kind, data.
         const string json = """
         {
-          "type": "run.started",
-          "seq": 0,
-          "ts": "2026-05-29T12:00:00Z"
+          "schema_version": 1,
+          "ts": "2026-05-29T12:00:00+00:00",
+          "kind": "started",
+          "data": {
+            "run_id": "00000000-0000-0000-0000-0000000000ff",
+            "agent_slug": "triage-agent",
+            "model_provider": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "tool_count": 0
+          }
         }
         """;
 
@@ -136,13 +167,15 @@ public class HeadlessConfigContractTests
     }
 
     [Fact]
-    public void ValidateEvent_UnknownType_Fails()
+    public void ValidateEvent_UnknownKind_Fails()
     {
+        // kind enum is closed; "exploded" is not a member.
         const string json = """
         {
-          "type": "run.exploded",
-          "seq": 0,
-          "ts": "2026-05-29T12:00:00Z"
+          "schema_version": 1,
+          "ts": "2026-05-29T12:00:00+00:00",
+          "kind": "exploded",
+          "data": {}
         }
         """;
 
@@ -158,7 +191,7 @@ public class HeadlessConfigContractTests
         var text = HeadlessConfigContract.GetConfigSchemaText();
 
         Assert.Contains("headless-config.v1.json", text);
-        Assert.Contains("\"version\"", text);
+        Assert.Contains("schema_version", text);
     }
 
     [Fact]

--- a/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigContractTests.cs
+++ b/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigContractTests.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+using Andy.Cli.Headless.Contract;
+using Xunit;
+
+namespace Andy.Cli.Tests.HeadlessConfig;
+
+/// <summary>
+/// Verifies the public contract-validation surface used by external generators.
+/// </summary>
+public class HeadlessConfigContractTests
+{
+    private static readonly string RepoRoot = GetRepoRoot();
+
+    private static string GetRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "Andy.Cli.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        return dir ?? throw new InvalidOperationException("Could not locate repository root.");
+    }
+
+    [Fact]
+    public void SchemaVersion_Is_One()
+    {
+        Assert.Equal(1, HeadlessConfigContract.SchemaVersion);
+    }
+
+    [Fact]
+    public void ValidateConfig_KnownGoodSample_Passes()
+    {
+        var samplePath = Path.Combine(RepoRoot, "schemas", "samples", "planning-headless.json");
+        var json = File.ReadAllText(samplePath);
+
+        var result = HeadlessConfigContract.ValidateConfig(json);
+
+        Assert.True(result.IsValid, "Expected the known-good sample to validate. Errors: " + string.Join("; ", result.Errors));
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void ValidateConfig_JsonElementOverload_Passes()
+    {
+        var samplePath = Path.Combine(RepoRoot, "schemas", "samples", "planning-headless.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(samplePath));
+
+        var result = HeadlessConfigContract.ValidateConfig(doc.RootElement);
+
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    [Fact]
+    public void ValidateConfig_UnknownProvider_Fails()
+    {
+        const string json = """
+        {
+          "version": 1,
+          "agent": { "name": "planner" },
+          "provider": { "name": "cohere" },
+          "task": { "prompt": "hello" }
+        }
+        """;
+
+        var result = HeadlessConfigContract.ValidateConfig(json);
+
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void ValidateConfig_MissingRequiredField_Fails()
+    {
+        // Missing the required "task" object.
+        const string json = """
+        {
+          "version": 1,
+          "agent": { "name": "planner" },
+          "provider": { "name": "openai" }
+        }
+        """;
+
+        var result = HeadlessConfigContract.ValidateConfig(json);
+
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void ValidateConfig_WrongVersionConstant_Fails()
+    {
+        const string json = """
+        {
+          "version": 2,
+          "agent": { "name": "planner" },
+          "provider": { "name": "openai" },
+          "task": { "prompt": "hello" }
+        }
+        """;
+
+        var result = HeadlessConfigContract.ValidateConfig(json);
+
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void ValidateConfig_MalformedJson_FailsWithError()
+    {
+        var result = HeadlessConfigContract.ValidateConfig("{ not json");
+
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void ValidateConfig_NullJson_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => HeadlessConfigContract.ValidateConfig((string)null!));
+    }
+
+    [Fact]
+    public void ValidateEvent_ValidRecord_Passes()
+    {
+        const string json = """
+        {
+          "type": "run.started",
+          "seq": 0,
+          "ts": "2026-05-29T12:00:00Z"
+        }
+        """;
+
+        var result = HeadlessConfigContract.ValidateEvent(json);
+
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    [Fact]
+    public void ValidateEvent_UnknownType_Fails()
+    {
+        const string json = """
+        {
+          "type": "run.exploded",
+          "seq": 0,
+          "ts": "2026-05-29T12:00:00Z"
+        }
+        """;
+
+        var result = HeadlessConfigContract.ValidateEvent(json);
+
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void GetConfigSchemaText_ReturnsEmbeddedSchema()
+    {
+        var text = HeadlessConfigContract.GetConfigSchemaText();
+
+        Assert.Contains("headless-config.v1.json", text);
+        Assert.Contains("\"version\"", text);
+    }
+
+    [Fact]
+    public void GetEventSchemaText_ReturnsEmbeddedSchema()
+    {
+        var text = HeadlessConfigContract.GetEventSchemaText();
+
+        Assert.Contains("headless-events.v1.json", text);
+    }
+}


### PR DESCRIPTION
Closes #54

## Summary
Adds `Andy.Cli.Headless.Contract`, a small, packable .NET 8 class library that lets external generators (andy-containers Epic AP12, conductor) verify their generated headless config and event records against the canonical Andy CLI schemas, without depending on the full CLI.

## What's included
- New project `src/Andy.Cli.Headless.Contract`:
  - Embeds `schemas/headless-config.v1.json` and `schemas/headless-events.v1.json` as linked embedded resources (single source of truth; no content duplication).
  - Public `HeadlessConfigContract` static API (XML-documented):
    - `const int SchemaVersion = 1`
    - `ValidateConfig(string)` and `ValidateConfig(JsonElement)`
    - `ValidateEvent(string)` and `ValidateEvent(JsonElement)`
    - `GetConfigSchemaText()` / `GetEventSchemaText()` to retrieve the raw schemas
  - `ValidationResult { bool IsValid; IReadOnlyList<string> Errors }` with errors annotated by instance location.
  - Uses JsonSchema.Net 9.2.0 (matches the consuming runtime and the existing test project).
  - Packable: `PackageId=Andy.Cli.Headless.Contract`, Description, `Version=2026.5.29-rc.1`. Not pushed to nuget.org.
- Registered in `Andy.Cli.sln`.
- Tests in `tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigContractTests.cs` (added to the explicit Compile include list and wired via ProjectReference), covering: known-good sample passes, an inline fully-valid config passes, the JsonElement overload passes, unknown provider (`cohere`) fails, missing required field (`limits`) fails, wrong `schema_version` const fails, malformed JSON returns errors, null throws, a valid event passes, an unknown event `kind` fails, and `SchemaVersion == 1` plus raw schema-text retrieval.

## Verification
- `dotnet build Andy.Cli.sln` succeeds.
- `dotnet test tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj`: Passed 277, Failed 0, Skipped 1 (pre-existing). The 13 new contract cases all pass.
- `dotnet pack` produces `Andy.Cli.Headless.Contract.2026.5.29-rc.1.nupkg`.