### PR TITLE
Headless cancel protocol: graceful SIGTERM/SIGINT shutdown

### DIFF
--- a/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
+++ b/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
@@ -144,6 +144,31 @@ public static class HeadlessAgentRunner
             return HeadlessExitCode.AgentFailure;
         }
 
+        // SimpleAgent may swallow the OperationCanceledException internally and
+        // return a failed result instead of throwing, so the catch above does
+        // not always see the cancel. Check the tokens directly: an outer ct
+        // cancel (SIGTERM) maps to Cancelled (3); the wall-clock timeout maps
+        // to Timeout (4). Either way we stop here without writing output, so no
+        // partial output is produced.
+        if (linkedCts.IsCancellationRequested)
+        {
+            iterations = result?.TurnCount ?? agent.GetHistory().Count / 2;
+            if (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+            {
+                emitter.EmitError(
+                    $"Agent loop exceeded timeout_seconds={timeoutSeconds}.",
+                    fatal: true);
+                exitCode = HeadlessExitCode.Timeout;
+            }
+            else
+            {
+                emitter.EmitError("Agent loop cancelled.", fatal: true);
+                exitCode = HeadlessExitCode.Cancelled;
+            }
+            EmitFinished(emitter, stopwatch, iterations, exitCode);
+            return exitCode;
+        }
+
         // SimpleAgent reports loop-level success; max_turns hits land here as
         // Success=false with StopReason="max_turns". Treat that as Timeout
         // to match the headless contract (max_iterations → exit 4).

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -84,6 +84,38 @@ class Program
         return (_gitBranch, _gitCommit);
     }
 
+    // AQ5 (rivoli-ai/andy-cli#50): cancel protocol for headless runs. When
+    // andy-containers sends SIGTERM (or SIGINT for Ctrl+C), cancel a CTS so
+    // HeadlessRunner.RunAsync follows its graceful shutdown path (flush events,
+    // exit code 3, no partial output) instead of being killed abruptly. The
+    // wall-clock timeout is handled separately inside HeadlessAgentRunner.
+    private static async Task<Andy.Cli.HeadlessConfig.HeadlessExitCode> RunHeadlessAsync(string[] args)
+    {
+        using var cts = new CancellationTokenSource();
+
+        void HandleSignal(System.Runtime.InteropServices.PosixSignalContext context)
+        {
+            // Suppress the runtime's default abrupt termination so our graceful
+            // shutdown path runs; cancellation flows through HeadlessRunner.
+            context.Cancel = true;
+            try
+            {
+                cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Run already completed and disposed the CTS; nothing to cancel.
+            }
+        }
+
+        using var sigterm = System.Runtime.InteropServices.PosixSignalRegistration.Create(
+            System.Runtime.InteropServices.PosixSignal.SIGTERM, HandleSignal);
+        using var sigint = System.Runtime.InteropServices.PosixSignalRegistration.Create(
+            System.Runtime.InteropServices.PosixSignal.SIGINT, HandleSignal);
+
+        return await Andy.Cli.HeadlessConfig.HeadlessRunner.RunAsync(args, ct: cts.Token);
+    }
+
     static async Task Main(string[] args)
     {
         // Debug: Check if ANDY_DEBUG_RAW is set
@@ -113,7 +145,7 @@ class Program
         // doesn't fit the ICommand Success/Fail → exit 0|1 scheme.
         if (args.Length > 0 && args[0] == "run")
         {
-            var exitCode = await Andy.Cli.HeadlessConfig.HeadlessRunner.RunAsync(args);
+            var exitCode = await RunHeadlessAsync(args);
             Environment.Exit((int)exitCode);
         }
 

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -64,6 +64,8 @@
     <Compile Include="HeadlessConfig/HeadlessRunnerTests.cs" />
     <!-- Headless provider/model resolution (OpenRouter) -->
     <Compile Include="HeadlessConfig/HeadlessProviderModelTests.cs" />
+    <!-- AQ5 headless cancel/timeout protocol tests (rivoli-ai/andy-cli#50) -->
+    <Compile Include="Headless/HeadlessAgentRunnerCancelTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Cli.Tests/Headless/HeadlessAgentRunnerCancelTests.cs
+++ b/tests/Andy.Cli.Tests/Headless/HeadlessAgentRunnerCancelTests.cs
@@ -1,0 +1,206 @@
+// AQ5 (rivoli-ai/andy-cli#50): cancel-protocol tests for the headless agent
+// loop. SIGTERM (and SIGINT) from andy-containers are wired in Program.cs to
+// cancel a CancellationTokenSource whose token flows into
+// HeadlessAgentRunner.ExecuteAsync. A true in-process SIGTERM is impractical
+// to deliver deterministically in xUnit (it would tear down the test host),
+// so these tests exercise the exact cancellation-token path SIGTERM triggers:
+// the token is cancelled mid-run and we assert the graceful contract — exit
+// code 3 (Cancelled), a flushed `finished` event carrying exit_code 3, and
+// no output file written (no partial output).
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Andy.Cli.Headless;
+using Andy.Cli.HeadlessConfig;
+using Andy.Model.Llm;
+using Andy.Model.Model;
+using Andy.Model.Tooling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Cli.Tests.Headless;
+
+public class HeadlessAgentRunnerCancelTests
+{
+    [Fact]
+    public async Task ExecuteAsync_TokenCancelledMidRun_MapsToExitCode3_FlushesFinished_NoOutputFile()
+    {
+        using var workspace = new TempDir();
+        var outputPath = Path.Combine(workspace.Path, "output.json");
+
+        var config = new HeadlessRunConfig
+        {
+            SchemaVersion = 1,
+            RunId = Guid.NewGuid(),
+            Agent = new HeadlessAgent { Slug = "stub", Instructions = "stub" },
+            Model = new HeadlessModel { Provider = "stub", Id = "stub-1" },
+            Tools = Array.Empty<HeadlessTool>(),
+            Workspace = new HeadlessWorkspace { Root = workspace.Path },
+            Output = new HeadlessOutput { File = outputPath, Stream = "stdout" },
+            // Generous wall-clock timeout so the outer cancel (not the timeout)
+            // is unambiguously what stops the run.
+            Limits = new HeadlessLimits { MaxIterations = 4, TimeoutSeconds = 120 },
+        };
+
+        var (stdout, stderr) = NewIo();
+        using var cts = new CancellationTokenSource();
+
+        // The fake completion blocks until the run's token is cancelled, then
+        // surfaces the cancellation exactly as a real provider would — this is
+        // the same signal a SIGTERM-cancelled CTS produces.
+        var llm = new BlockUntilCancelledLlmProvider(onEnter: cts.Cancel);
+
+        var code = await HeadlessAgentRunner.ExecuteAsync(
+            config, stdout, stderr, NullLoggerFactory.Instance,
+            llmProviderOverride: llm, ct: cts.Token);
+
+        Assert.Equal(HeadlessExitCode.Cancelled, code);
+
+        // No partial output: the output file must not exist after a cancel.
+        Assert.False(File.Exists(outputPath));
+
+        // The `finished` event was flushed and carries exit_code 3.
+        var events = ParseEvents(stdout.ToString());
+        var finished = events.Last();
+        Assert.Equal("finished", finished.GetProperty("kind").GetString());
+        Assert.Equal(3, finished.GetProperty("data").GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TokenAlreadyCancelled_StillEmitsFinishedWithExitCode3()
+    {
+        using var workspace = new TempDir();
+        var outputPath = Path.Combine(workspace.Path, "output.json");
+
+        var config = new HeadlessRunConfig
+        {
+            SchemaVersion = 1,
+            RunId = Guid.NewGuid(),
+            Agent = new HeadlessAgent { Slug = "stub", Instructions = "stub" },
+            Model = new HeadlessModel { Provider = "stub", Id = "stub-1" },
+            Tools = Array.Empty<HeadlessTool>(),
+            Workspace = new HeadlessWorkspace { Root = workspace.Path },
+            Output = new HeadlessOutput { File = outputPath, Stream = "stdout" },
+            Limits = new HeadlessLimits { MaxIterations = 4, TimeoutSeconds = 120 },
+        };
+
+        var (stdout, stderr) = NewIo();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var llm = new BlockUntilCancelledLlmProvider();
+
+        var code = await HeadlessAgentRunner.ExecuteAsync(
+            config, stdout, stderr, NullLoggerFactory.Instance,
+            llmProviderOverride: llm, ct: cts.Token);
+
+        Assert.Equal(HeadlessExitCode.Cancelled, code);
+        Assert.False(File.Exists(outputPath));
+
+        var events = ParseEvents(stdout.ToString());
+        var finished = events.Last();
+        Assert.Equal("finished", finished.GetProperty("kind").GetString());
+        Assert.Equal(3, finished.GetProperty("data").GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TimeoutBeatsCancel_MapsToExitCode4()
+    {
+        using var workspace = new TempDir();
+        var outputPath = Path.Combine(workspace.Path, "output.json");
+
+        var config = new HeadlessRunConfig
+        {
+            SchemaVersion = 1,
+            RunId = Guid.NewGuid(),
+            Agent = new HeadlessAgent { Slug = "stub", Instructions = "stub" },
+            Model = new HeadlessModel { Provider = "stub", Id = "stub-1" },
+            Tools = Array.Empty<HeadlessTool>(),
+            Workspace = new HeadlessWorkspace { Root = workspace.Path },
+            Output = new HeadlessOutput { File = outputPath, Stream = "stdout" },
+            // 1-second wall-clock timeout vs a never-completing provider, with
+            // an outer token that is never cancelled — the timeout path wins.
+            Limits = new HeadlessLimits { MaxIterations = 4, TimeoutSeconds = 1 },
+        };
+
+        var (stdout, stderr) = NewIo();
+        var llm = new BlockUntilCancelledLlmProvider();
+
+        var code = await HeadlessAgentRunner.ExecuteAsync(
+            config, stdout, stderr, NullLoggerFactory.Instance,
+            llmProviderOverride: llm, ct: CancellationToken.None);
+
+        Assert.Equal(HeadlessExitCode.Timeout, code);
+        Assert.False(File.Exists(outputPath));
+
+        var events = ParseEvents(stdout.ToString());
+        var finished = events.Last();
+        Assert.Equal("finished", finished.GetProperty("kind").GetString());
+        Assert.Equal(4, finished.GetProperty("data").GetProperty("exit_code").GetInt32());
+    }
+
+    private static (StringWriter Stdout, StringWriter Stderr) NewIo()
+        => (new StringWriter(new StringBuilder()), new StringWriter(new StringBuilder()));
+
+    private static List<JsonElement> ParseEvents(string ndjson)
+    {
+        var lines = ndjson.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        return lines
+            .Select(l => JsonDocument.Parse(l).RootElement.Clone())
+            .ToList();
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"aq5-cancel-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    // CompleteAsync awaits the supplied token until it is cancelled, then
+    // throws OperationCanceledException — exactly how an in-flight model call
+    // reacts to a SIGTERM-cancelled token. An optional onEnter hook lets a
+    // test trip the cancel deterministically once the call is underway.
+    private sealed class BlockUntilCancelledLlmProvider : ILlmProvider
+    {
+        private readonly Action? _onEnter;
+
+        public BlockUntilCancelledLlmProvider(Action? onEnter = null)
+        {
+            _onEnter = onEnter;
+        }
+
+        public string Name => "stub";
+
+        public async Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken cancellationToken = default)
+        {
+            _onEnter?.Invoke();
+            // Block until cancellation; Task.Delay(Infinite) throws
+            // TaskCanceledException (an OperationCanceledException) when the
+            // token fires.
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            throw new InvalidOperationException("Unreachable: provider should be cancelled.");
+        }
+
+        public async IAsyncEnumerable<LlmStreamResponse> StreamCompleteAsync(
+            LlmRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            yield break;
+        }
+
+        public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public Task<IEnumerable<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Enumerable.Empty<ModelInfo>());
+    }
+}


### PR DESCRIPTION
Closes #50

## Summary
When andy-containers sends SIGTERM (or the operator presses Ctrl+C, SIGINT), a headless run now cancels gracefully instead of being killed abruptly: it flushes the event stream, emits a `finished` event with exit code 3 (Cancelled), and does not write partial output.

## Changes
- `src/Andy.Cli/Program.cs`: the headless `run` branch now goes through a new `RunHeadlessAsync` helper that creates a `CancellationTokenSource`, registers `PosixSignalRegistration` handlers for `PosixSignal.SIGTERM` and `PosixSignal.SIGINT`, sets `PosixSignalContext.Cancel = true` to suppress the runtime default abrupt termination, cancels the CTS, and passes the token to `HeadlessRunner.RunAsync`. Registrations are disposed via `using`. Headless-only; the interactive path is untouched.
- `src/Andy.Cli/Headless/HeadlessAgentRunner.cs`: the runner previously detected cancellation only via the agent loop throwing `OperationCanceledException`. SimpleAgent can instead swallow the cancellation internally and return a failed result, which fell through to AgentFailure (exit 1). Added an explicit post-loop check on the linked token: an outer-ct cancel maps to Cancelled (3) and the wall-clock timeout maps to Timeout (4), returning before any output is written.

## Tests
New `tests/Andy.Cli.Tests/Headless/HeadlessAgentRunnerCancelTests.cs` (registered in the test csproj Compile list) drives `HeadlessAgentRunner.ExecuteAsync` with a fake `ILlmProvider` whose completion blocks until its token is cancelled:
- token cancelled mid-run -> exit code 3, flushed `finished` event with `exit_code: 3`, output file not created
- already-cancelled token -> same graceful result
- short `timeout_seconds` against a never-completing provider -> exit code 4 (Timeout), no output file

## Verification
- `dotnet build src/Andy.Cli/Andy.Cli.csproj`: build succeeded, 0 warnings.
- `dotnet test tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj`: Passed - Failed: 0, Passed: 268, Skipped: 1, Total: 269 (the 3 new cancel/timeout tests included).

## Note on the signal test
A true end-to-end in-process SIGTERM is impractical in xUnit (it would tear down the test host), so the tests exercise the cancellation-token path that SIGTERM triggers, which is exactly what the `PosixSignalRegistration` handler cancels.