### PR TITLE
AQ7: headless runtime stability and regression fixture tests

### DIFF
--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -64,6 +64,8 @@
     <Compile Include="HeadlessConfig/HeadlessRunnerTests.cs" />
     <!-- Headless provider/model resolution (OpenRouter) -->
     <Compile Include="HeadlessConfig/HeadlessProviderModelTests.cs" />
+    <!-- AQ7 headless stability + regression fixture tests (rivoli-ai/andy-cli#52) -->
+    <Compile Include="Headless/HeadlessAgentRunnerStabilityTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Cli.Tests/Headless/HeadlessAgentRunnerStabilityTests.cs
+++ b/tests/Andy.Cli.Tests/Headless/HeadlessAgentRunnerStabilityTests.cs
@@ -1,0 +1,418 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Cli.Headless;
+using Andy.Cli.HeadlessConfig;
+using Andy.Model.Llm;
+using Andy.Model.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Cli.Tests.Headless;
+
+// AQ7 stability + regression coverage (rivoli-ai/andy-cli#52).
+//
+// The epic treats headless flakiness as a blocking bug, so these are
+// deterministic, network-free integration tests that drive the real headless
+// agent loop (HeadlessAgentRunner.ExecuteAsync) against a scripted in-memory
+// ILlmProvider passed through the llmProviderOverride hook. Each test captures
+// the NDJSON event stream into a StringWriter, parses every line as JSON, and
+// asserts on event kinds, ordering, and key fields so a regression that
+// reorders, drops, or malforms an event fails loudly.
+//
+// Scope per the issue: exercise each event kind produced by
+// HeadlessEventEmitter / HeadlessAgentRunner (started, output_written,
+// tool_call_started, tool_call_finished, error, finished) and the Success (0)
+// and AgentFailure (1) exit-code paths, plus a real cli-transport tool
+// round-trip. The cancel / timeout paths (exit 3 / 4, SIGTERM) are owned by
+// issue #50 and are intentionally NOT covered here. ConfigError (exit 2)
+// schema-validation paths live in HeadlessRunnerTests; this file adds the
+// ExecuteAsync-level AgentFailure paths not covered there.
+public class HeadlessAgentRunnerStabilityTests
+{
+    [Fact]
+    public async Task FinalTextResponse_EmitsStartedOutputFinished_AndExitsSuccess()
+    {
+        using var ws = new TempDir();
+        var config = NewConfig(ws);
+        var provider = new FakeLlmProvider(FakeLlmProvider.TextResponse("The answer is 42."));
+
+        var (events, code) = await RunAsync(config, provider);
+
+        Assert.Equal(HeadlessExitCode.Success, code);
+
+        // Ordering contract: started first, finished last, no error.
+        Assert.Equal("started", events.First().Kind);
+        Assert.Equal("finished", events.Last().Kind);
+        Assert.DoesNotContain(events, e => e.Kind == "error");
+
+        var started = events.Single(e => e.Kind == "started");
+        Assert.Equal(config.RunId.ToString(), started.Data.GetProperty("run_id").GetString());
+        Assert.Equal(config.Agent.Slug, started.Data.GetProperty("agent_slug").GetString());
+        Assert.Equal(config.Model.Provider, started.Data.GetProperty("model_provider").GetString());
+        Assert.Equal(config.Model.Id, started.Data.GetProperty("model_id").GetString());
+        Assert.Equal(0, started.Data.GetProperty("tool_count").GetInt32());
+
+        var output = events.Single(e => e.Kind == "output_written");
+        Assert.Equal(config.Output.File, output.Data.GetProperty("path").GetString());
+        Assert.True(output.Data.GetProperty("bytes").GetInt64() > 0);
+
+        var finished = events.Single(e => e.Kind == "finished");
+        Assert.Equal(0, finished.Data.GetProperty("exit_code").GetInt32());
+        Assert.True(finished.Data.GetProperty("duration_ms").GetInt64() >= 0);
+        Assert.True(finished.Data.TryGetProperty("iterations", out _));
+
+        // The final text is persisted atomically to the configured output file.
+        Assert.Equal("The answer is 42.", File.ReadAllText(config.Output.File));
+
+        // Every event carries the envelope contract.
+        foreach (var e in events)
+        {
+            Assert.Equal(HeadlessEventEmitter.SchemaVersion, e.SchemaVersion);
+            Assert.False(string.IsNullOrEmpty(e.Kind));
+        }
+    }
+
+    [Fact]
+    public async Task ToolCallThenFinalResponse_EmitsPairedToolCallEvents()
+    {
+        using var ws = new TempDir();
+        // Register a real, no-op cli tool so the scripted tool call resolves to
+        // an actual adapter and SimpleAgent fires its ToolCalled event.
+        var noop = CrossPlatform.NoOpCliTool("noop");
+        var config = NewConfig(ws) with { Tools = new[] { noop } };
+
+        var provider = new FakeLlmProvider(
+            FakeLlmProvider.ToolCallResponse("noop", new { args = System.Array.Empty<string>() }),
+            FakeLlmProvider.TextResponse("done"));
+
+        var (events, code) = await RunAsync(config, provider);
+
+        Assert.Equal(HeadlessExitCode.Success, code);
+
+        var startedTool = events.Single(e => e.Kind == "tool_call_started");
+        Assert.Equal("noop", startedTool.Data.GetProperty("tool_name").GetString());
+        var callId = startedTool.Data.GetProperty("call_id").GetString();
+        Assert.False(string.IsNullOrEmpty(callId));
+
+        var finishedTool = events.Single(e => e.Kind == "tool_call_finished");
+        Assert.Equal("noop", finishedTool.Data.GetProperty("tool_name").GetString());
+        Assert.Equal(callId, finishedTool.Data.GetProperty("call_id").GetString());
+        Assert.True(finishedTool.Data.GetProperty("ok").GetBoolean());
+        Assert.True(finishedTool.Data.TryGetProperty("duration_ms", out _));
+
+        // tool_call_started precedes tool_call_finished; both sit inside the
+        // started..finished envelope.
+        var kinds = events.Select(e => e.Kind).ToList();
+        Assert.True(kinds.IndexOf("tool_call_started") < kinds.IndexOf("tool_call_finished"));
+        Assert.True(kinds.IndexOf("started") < kinds.IndexOf("tool_call_started"));
+        Assert.True(kinds.IndexOf("tool_call_finished") < kinds.LastIndexOf("finished"));
+    }
+
+    [Fact]
+    public async Task CliTransportTool_RoundTripsThroughRealSubprocess()
+    {
+        using var ws = new TempDir();
+        // A trivial real binary written into a temp dir that echoes a marker.
+        var echo = CrossPlatform.WriteEchoScript(ws.Path, "AQ7-ROUNDTRIP-MARKER");
+        var config = NewConfig(ws) with { Tools = new[] { echo } };
+
+        var provider = new FakeLlmProvider(
+            FakeLlmProvider.ToolCallResponse("echo_marker", new { args = System.Array.Empty<string>() }),
+            FakeLlmProvider.TextResponse("subprocess invoked"));
+
+        var (events, code) = await RunAsync(config, provider);
+
+        Assert.Equal(HeadlessExitCode.Success, code);
+        Assert.Equal("echo_marker", events.Single(e => e.Kind == "tool_call_started").Data.GetProperty("tool_name").GetString());
+        Assert.True(events.Single(e => e.Kind == "tool_call_finished").Data.GetProperty("ok").GetBoolean());
+
+        // started reports the real tool_count from config.
+        Assert.Equal(1, events.Single(e => e.Kind == "started").Data.GetProperty("tool_count").GetInt32());
+    }
+
+    [Fact]
+    public async Task ProviderThrows_EmitsFatalErrorAndExitsAgentFailure()
+    {
+        using var ws = new TempDir();
+        var config = NewConfig(ws);
+        var provider = new FakeLlmProvider(() => throw new InvalidOperationException("provider exploded"));
+
+        var (events, code) = await RunAsync(config, provider);
+
+        Assert.Equal(HeadlessExitCode.AgentFailure, code);
+
+        // started still first, finished still last.
+        Assert.Equal("started", events.First().Kind);
+        Assert.Equal("finished", events.Last().Kind);
+
+        var error = events.Single(e => e.Kind == "error");
+        Assert.True(error.Data.GetProperty("fatal").GetBoolean());
+        Assert.False(string.IsNullOrEmpty(error.Data.GetProperty("message").GetString()));
+
+        var finished = events.Single(e => e.Kind == "finished");
+        Assert.Equal((int)HeadlessExitCode.AgentFailure, finished.Data.GetProperty("exit_code").GetInt32());
+
+        // No output file written on the failure path.
+        Assert.False(File.Exists(config.Output.File));
+        Assert.DoesNotContain(events, e => e.Kind == "output_written");
+    }
+
+    [Fact]
+    public async Task UnsupportedToolTransport_EmitsErrorBeforeStarted_AndExitsAgentFailure()
+    {
+        using var ws = new TempDir();
+        var config = NewConfig(ws) with
+        {
+            Tools = new[] { new HeadlessTool { Name = "broken", Transport = "smoke-signal" } },
+        };
+        // Provider should never be consulted; tool wiring fails first.
+        var provider = new FakeLlmProvider(FakeLlmProvider.TextResponse("unreachable"));
+
+        var (events, code) = await RunAsync(config, provider);
+
+        Assert.Equal(HeadlessExitCode.AgentFailure, code);
+        Assert.Equal(0, provider.CompleteCallCount);
+
+        // Tool wiring fails before `started`; stream is error then finished.
+        var error = events.Single(e => e.Kind == "error");
+        Assert.True(error.Data.GetProperty("fatal").GetBoolean());
+        var finished = events.Single(e => e.Kind == "finished");
+        Assert.Equal((int)HeadlessExitCode.AgentFailure, finished.Data.GetProperty("exit_code").GetInt32());
+        Assert.DoesNotContain(events, e => e.Kind == "started");
+    }
+
+    [Fact]
+    public async Task OutputFileUnwritable_EmitsErrorAndExitsAgentFailure()
+    {
+        using var ws = new TempDir();
+        // Point output.file under an existing *file* so the atomic write can
+        // neither create the directory nor open the temp file. Deterministic.
+        var blocker = Path.Combine(ws.Path, "blocker");
+        File.WriteAllText(blocker, "x");
+        var badOutput = Path.Combine(blocker, "out.txt");
+
+        var config = NewConfig(ws) with
+        {
+            Output = new HeadlessOutput { File = badOutput, Stream = "stdout" },
+        };
+        var provider = new FakeLlmProvider(FakeLlmProvider.TextResponse("cannot persist this"));
+
+        var (events, code) = await RunAsync(config, provider);
+
+        Assert.Equal(HeadlessExitCode.AgentFailure, code);
+        var error = events.Single(e => e.Kind == "error" && e.Data.GetProperty("fatal").GetBoolean());
+        Assert.Contains("output file", error.Data.GetProperty("message").GetString());
+
+        // started always first, finished always last, with the failure code.
+        Assert.Equal("started", events.First().Kind);
+        Assert.Equal("finished", events.Last().Kind);
+        Assert.Equal(
+            (int)HeadlessExitCode.AgentFailure,
+            events.Last().Data.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
+    public async Task EveryLineIsWellFormedNdjson()
+    {
+        // Regression guard against torn / non-JSON lines on the wire: one JSON
+        // object per line, each with the schema_version/ts/kind/data envelope.
+        using var ws = new TempDir();
+        var config = NewConfig(ws);
+        var provider = new FakeLlmProvider(FakeLlmProvider.TextResponse("ok"));
+
+        var stdout = new StringWriter(new StringBuilder());
+        var stderr = new StringWriter(new StringBuilder());
+        await HeadlessAgentRunner.ExecuteAsync(
+            config, stdout, stderr, NullLoggerFactory.Instance, provider);
+
+        var rawLines = stdout.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.NotEmpty(rawLines);
+        foreach (var line in rawLines)
+        {
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+            Assert.True(root.TryGetProperty("schema_version", out _));
+            Assert.True(root.TryGetProperty("ts", out _));
+            Assert.True(root.TryGetProperty("kind", out _));
+            Assert.True(root.TryGetProperty("data", out _));
+        }
+    }
+
+    // ---- harness -----------------------------------------------------------
+
+    private static async Task<(List<Evt> Events, HeadlessExitCode Code)> RunAsync(
+        HeadlessRunConfig config, ILlmProvider provider)
+    {
+        var stdout = new StringWriter(new StringBuilder());
+        var stderr = new StringWriter(new StringBuilder());
+
+        var code = await HeadlessAgentRunner.ExecuteAsync(
+            config, stdout, stderr, NullLoggerFactory.Instance, provider);
+
+        var events = stdout.ToString()
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(ParseEvent)
+            .ToList();
+
+        return (events, code);
+    }
+
+    private static Evt ParseEvent(string line)
+    {
+        using var doc = JsonDocument.Parse(line);
+        var root = doc.RootElement;
+        return new Evt(
+            root.GetProperty("schema_version").GetInt32(),
+            root.GetProperty("kind").GetString()!,
+            root.GetProperty("data").Clone());
+    }
+
+    private static HeadlessRunConfig NewConfig(TempDir ws) => new()
+    {
+        SchemaVersion = 1,
+        RunId = Guid.NewGuid(),
+        Agent = new HeadlessAgent { Slug = "aq7-agent", Instructions = "You are a test agent." },
+        Model = new HeadlessModel { Provider = "scripted", Id = "scripted-model" },
+        Tools = Array.Empty<HeadlessTool>(),
+        Workspace = new HeadlessWorkspace { Root = ws.Path },
+        Output = new HeadlessOutput { File = Path.Combine(ws.Path, "output.txt"), Stream = "stdout" },
+        Limits = new HeadlessLimits { MaxIterations = 5, TimeoutSeconds = 30 },
+    };
+
+    // Minimal parsed view of one NDJSON event line.
+    private sealed record Evt(int SchemaVersion, string Kind, JsonElement Data);
+
+    // ---- fakes -------------------------------------------------------------
+
+    // Deterministic in-memory provider. HeadlessAgentRunner wraps it in a
+    // SimpleAgent and drives it with a single kickoff message; each queued
+    // turn is returned once, in order, so the resulting event stream is fully
+    // reproducible. A turn may throw to drive the failure path.
+    private sealed class FakeLlmProvider : ILlmProvider
+    {
+        private readonly Queue<Func<LlmResponse>> _turns;
+        private LlmResponse? _last;
+
+        public FakeLlmProvider(params LlmResponse[] responses)
+            : this(responses.Select<LlmResponse, Func<LlmResponse>>(r => () => r))
+        {
+        }
+
+        public FakeLlmProvider(params Func<LlmResponse>[] turns)
+            : this((IEnumerable<Func<LlmResponse>>)turns)
+        {
+        }
+
+        private FakeLlmProvider(IEnumerable<Func<LlmResponse>> turns)
+        {
+            _turns = new Queue<Func<LlmResponse>>(turns);
+        }
+
+        public string Name => "scripted";
+
+        public int CompleteCallCount { get; private set; }
+
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken cancellationToken = default)
+        {
+            CompleteCallCount++;
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_turns.Count > 0)
+            {
+                _last = _turns.Dequeue()();
+            }
+            return Task.FromResult(_last ?? TextResponse(string.Empty));
+        }
+
+        public async IAsyncEnumerable<LlmStreamResponse> StreamCompleteAsync(
+            LlmRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await CompleteAsync(request, cancellationToken);
+            yield return new LlmStreamResponse
+            {
+                TextDelta = response.AssistantMessage?.Content ?? string.Empty,
+                IsComplete = true,
+            };
+        }
+
+        public Task<IEnumerable<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<ModelInfo>>(Array.Empty<ModelInfo>());
+
+        public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public static LlmResponse TextResponse(string text) => new()
+        {
+            AssistantMessage = new Message
+            {
+                Role = Role.Assistant,
+                Parts = { new TextPart { Text = text } },
+            },
+        };
+
+        public static LlmResponse ToolCallResponse(string toolName, object args) => new()
+        {
+            AssistantMessage = new Message
+            {
+                Role = Role.Assistant,
+                Parts =
+                {
+                    new ToolCallPart
+                    {
+                        ToolName = toolName,
+                        CallId = Guid.NewGuid().ToString("N")[..8],
+                        Arguments = args,
+                    },
+                },
+            },
+        };
+    }
+
+    // Helpers that pick real, no-dependency binaries for the cli-transport
+    // tests so they run unchanged on POSIX and Windows hosts.
+    private static class CrossPlatform
+    {
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // A cli tool that exits 0 and needs no input. On POSIX /bin/echo, on
+        // Windows cmd /c echo. CliSubprocessTool treats a zero exit as success.
+        public static HeadlessTool NoOpCliTool(string name) => IsWindows
+            ? new HeadlessTool { Name = name, Transport = "cli", Binary = "cmd.exe", Command = new[] { "cmd.exe", "/c", "echo" } }
+            : new HeadlessTool { Name = name, Transport = "cli", Binary = "/bin/echo", Command = new[] { "/bin/echo" } };
+
+        // Writes a tiny script into <dir> that echoes <marker> and exits 0,
+        // returning a HeadlessTool named "echo_marker" that invokes it.
+        public static HeadlessTool WriteEchoScript(string dir, string marker)
+        {
+            if (IsWindows)
+            {
+                var bat = Path.Combine(dir, "echo_marker.bat");
+                File.WriteAllText(bat, $"@echo {marker}\r\n");
+                return new HeadlessTool
+                {
+                    Name = "echo_marker",
+                    Transport = "cli",
+                    Binary = "cmd.exe",
+                    Command = new[] { "cmd.exe", "/c", bat },
+                };
+            }
+
+            var sh = Path.Combine(dir, "echo_marker.sh");
+            File.WriteAllText(sh, $"#!/bin/sh\necho {marker}\n");
+            return new HeadlessTool
+            {
+                Name = "echo_marker",
+                Transport = "cli",
+                Binary = "/bin/sh",
+                Command = new[] { "/bin/sh", sh },
+            };
+        }
+    }
+}

--- a/tests/Andy.Cli.Tests/Headless/HeadlessAgentRunnerStabilityTests.cs
+++ b/tests/Andy.Cli.Tests/Headless/HeadlessAgentRunnerStabilityTests.cs
@@ -85,11 +85,10 @@ public class HeadlessAgentRunnerStabilityTests
         using var ws = new TempDir();
         // Register a real, no-op cli tool so the scripted tool call resolves to
         // an actual adapter and SimpleAgent fires its ToolCalled event.
-        var noop = CrossPlatform.NoOpCliTool("noop");
-        var config = NewConfig(ws) with { Tools = new[] { noop } };
+        var config = NewConfig(ws) with { Tools = new[] { CrossPlatform.NoOpCliTool("noop") } };
 
         var provider = new FakeLlmProvider(
-            FakeLlmProvider.ToolCallResponse("noop", new { args = System.Array.Empty<string>() }),
+            FakeLlmProvider.ToolCallResponse("noop", "call-1"),
             FakeLlmProvider.TextResponse("done"));
 
         var (events, code) = await RunAsync(config, provider);
@@ -124,7 +123,7 @@ public class HeadlessAgentRunnerStabilityTests
         var config = NewConfig(ws) with { Tools = new[] { echo } };
 
         var provider = new FakeLlmProvider(
-            FakeLlmProvider.ToolCallResponse("echo_marker", new { args = System.Array.Empty<string>() }),
+            FakeLlmProvider.ToolCallResponse("echo_marker", "call-echo"),
             FakeLlmProvider.TextResponse("subprocess invoked"));
 
         var (events, code) = await RunAsync(config, provider);
@@ -289,12 +288,28 @@ public class HeadlessAgentRunnerStabilityTests
     // Minimal parsed view of one NDJSON event line.
     private sealed record Evt(int SchemaVersion, string Kind, JsonElement Data);
 
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"aq7-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+        public void Dispose()
+        {
+            try { if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true); }
+            catch { /* best-effort */ }
+        }
+    }
+
     // ---- fakes -------------------------------------------------------------
 
     // Deterministic in-memory provider. HeadlessAgentRunner wraps it in a
-    // SimpleAgent and drives it with a single kickoff message; each queued
-    // turn is returned once, in order, so the resulting event stream is fully
-    // reproducible. A turn may throw to drive the failure path.
+    // SimpleAgent and drives it with a single kickoff message; each queued turn
+    // is returned once, in order, so the resulting event stream is fully
+    // reproducible. A turn may throw to drive the failure path. Mirrors the
+    // Message/ToolCall idiom SimpleAgent expects (see the AQ3 StubLlmProvider).
     private sealed class FakeLlmProvider : ILlmProvider
     {
         private readonly Queue<Func<LlmResponse>> _turns;
@@ -334,44 +349,56 @@ public class HeadlessAgentRunnerStabilityTests
             LlmRequest request,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            // SimpleAgent's headless loop uses CompleteAsync; implement streaming
+            // as a single terminal chunk for completeness.
             var response = await CompleteAsync(request, cancellationToken);
             yield return new LlmStreamResponse
             {
-                TextDelta = response.AssistantMessage?.Content ?? string.Empty,
+                Delta = response.AssistantMessage,
                 IsComplete = true,
+                FinishReason = response.FinishReason,
             };
         }
-
-        public Task<IEnumerable<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult<IEnumerable<ModelInfo>>(Array.Empty<ModelInfo>());
 
         public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(true);
 
+        public Task<IEnumerable<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Enumerable.Empty<ModelInfo>());
+
+        // A final assistant message with no tool calls and FinishReason="stop"
+        // terminates SimpleAgent's loop after one turn.
         public static LlmResponse TextResponse(string text) => new()
         {
             AssistantMessage = new Message
             {
                 Role = Role.Assistant,
-                Parts = { new TextPart { Text = text } },
+                Content = text,
+                ToolCalls = new List<ToolCall>(),
             },
+            FinishReason = "stop",
+            Model = "scripted-model",
         };
 
-        public static LlmResponse ToolCallResponse(string toolName, object args) => new()
+        // An assistant message carrying a single tool call drives one tool turn.
+        public static LlmResponse ToolCallResponse(string toolName, string callId) => new()
         {
             AssistantMessage = new Message
             {
                 Role = Role.Assistant,
-                Parts =
+                Content = string.Empty,
+                ToolCalls = new List<ToolCall>
                 {
-                    new ToolCallPart
+                    new()
                     {
-                        ToolName = toolName,
-                        CallId = Guid.NewGuid().ToString("N")[..8],
-                        Arguments = args,
+                        Id = callId,
+                        Name = toolName,
+                        ArgumentsJson = "{\"args\":[]}",
                     },
                 },
             },
+            FinishReason = "tool_calls",
+            Model = "scripted-model",
         };
     }
 
@@ -381,11 +408,11 @@ public class HeadlessAgentRunnerStabilityTests
     {
         private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-        // A cli tool that exits 0 and needs no input. On POSIX /bin/echo, on
-        // Windows cmd /c echo. CliSubprocessTool treats a zero exit as success.
+        // A cli tool that exits 0 and needs no input. CliSubprocessTool treats a
+        // zero exit as success regardless of stdout.
         public static HeadlessTool NoOpCliTool(string name) => IsWindows
-            ? new HeadlessTool { Name = name, Transport = "cli", Binary = "cmd.exe", Command = new[] { "cmd.exe", "/c", "echo" } }
-            : new HeadlessTool { Name = name, Transport = "cli", Binary = "/bin/echo", Command = new[] { "/bin/echo" } };
+            ? new HeadlessTool { Name = name, Transport = "cli", Binary = "cmd", Command = new[] { "cmd", "/c", "echo" } }
+            : new HeadlessTool { Name = name, Transport = "cli", Binary = "echo", Command = new[] { "echo" } };
 
         // Writes a tiny script into <dir> that echoes <marker> and exits 0,
         // returning a HeadlessTool named "echo_marker" that invokes it.
@@ -399,8 +426,8 @@ public class HeadlessAgentRunnerStabilityTests
                 {
                     Name = "echo_marker",
                     Transport = "cli",
-                    Binary = "cmd.exe",
-                    Command = new[] { "cmd.exe", "/c", bat },
+                    Binary = "cmd",
+                    Command = new[] { "cmd", "/c", bat },
                 };
             }
 
@@ -410,8 +437,8 @@ public class HeadlessAgentRunnerStabilityTests
             {
                 Name = "echo_marker",
                 Transport = "cli",
-                Binary = "/bin/sh",
-                Command = new[] { "/bin/sh", sh },
+                Binary = "sh",
+                Command = new[] { "sh", sh },
             };
         }
     }


### PR DESCRIPTION
Closes #52

## Summary

Adds deterministic, network-free integration coverage for the headless agent loop. Each run is driven by a scripted in-memory `ILlmProvider` (`FakeLlmProvider`) handed to `HeadlessAgentRunner.ExecuteAsync` via the `llmProviderOverride` hook, so the NDJSON event stream is fully reproducible with no live LLM or network access. Tests capture stdout into a `StringWriter`, parse each line as JSON, and assert on event kinds, ordering, and key fields.

### Event kinds and exit codes covered
- `started` / `output_written` / `finished` with exit code 0 (Success) on a final text response — envelope, field, and atomic output-file content assertions.
- `tool_call_started` / `tool_call_finished` on a scripted tool call — `call_id` pairing and event ordering.
- `error` (fatal) plus exit code 1 (AgentFailure) when the provider throws, when an unsupported tool transport fails wiring before `started`, and when the output file cannot be persisted.
- NDJSON well-formedness regression guard over every emitted line (schema_version / ts / kind / data envelope).

### Tool transports
- `cli` transport: a real round-trip through `CliSubprocessTool` invoking a trivial shell script written to a temp dir, plus a no-op `/bin/echo` binding. A small cross-platform helper picks portable binaries for POSIX and Windows hosts.
- `mcp` transport: not exercised here — it requires a live MCP server and would be flaky. Documented as a gap below.

### Out of scope
Cancel / timeout paths (exit codes 3 and 4, SIGTERM) are intentionally excluded; they are owned by issue #50. ConfigError (exit 2) schema-validation paths remain in `HeadlessRunnerTests`; this PR adds the `ExecuteAsync`-level AgentFailure paths not already covered there.

## Verification
- `dotnet build tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj` succeeds.
- Full test project run twice, deterministic: 59 passed, 0 failed both runs (7 new tests).
- `dotnet format --verify-no-changes` clean on the new file.

Note: on the .NET 10 SDK present on the dev host, `dotnet test` defaults to the Microsoft.Testing.Platform path which reports an unusable failure; running with `-p:TestingPlatformDotnetTestSupport=false` (classic VSTest) runs the suite normally. This is an environment quirk, not a test issue.

## Gaps
- `mcp` transport remains uncovered by automated tests pending a fixture MCP server.
- The output-file-unwritable path emits `started, output_written, error, finished` (exit 1); the test asserts the AgentFailure exit code, a fatal output-file error, and started-first / finished-last ordering rather than forbidding an interim event, reflecting the runner's current behavior.
