### PR TITLE
Fix broken test csproj merge and global schema-registry collision

### DIFF
--- a/src/Andy.Cli.Headless.Contract/HeadlessConfigContract.cs
+++ b/src/Andy.Cli.Headless.Contract/HeadlessConfigContract.cs
@@ -33,8 +33,23 @@ public static class HeadlessConfigContract
     private static readonly Lazy<JsonSchema> EventSchemaLazy = new(() => ParseSchema(EventSchemaTextLazy.Value));
 
     private static JsonSchema ParseSchema(string text)
-        => JsonSerializer.Deserialize<JsonSchema>(text)
+    {
+        // JsonSchema.Net registers any schema carrying an "$id" into a process-global
+        // SchemaRegistry and throws "Overwriting registered schemas is not permitted"
+        // if another component (e.g. the andy-cli test suite's own schema loader)
+        // registers the same $id. These schemas contain no internal "$ref", so the
+        // $id is unused for resolution here; strip it before building so evaluation
+        // stays isolated and never collides with another registrant.
+        var node = JsonNode.Parse(text)
+            ?? throw new InvalidOperationException("Embedded schema text parsed to null.");
+        if (node is JsonObject obj)
+        {
+            obj.Remove("$id");
+        }
+
+        return JsonSerializer.Deserialize<JsonSchema>(node)
             ?? throw new InvalidOperationException("Embedded schema text deserialized to null.");
+    }
 
     /// <summary>
     /// Gets the raw JSON text of the embedded headless configuration schema.

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -65,15 +65,12 @@
     <Compile Include="HeadlessConfig/HeadlessRunnerTests.cs" />
     <!-- Headless provider/model resolution (OpenRouter) -->
     <Compile Include="HeadlessConfig/HeadlessProviderModelTests.cs" />
-<<<<<<< HEAD
-    <!-- AQ8 headless contract validation library (rivoli-ai/andy-cli#54) -->
-    <Compile Include="HeadlessConfig/HeadlessConfigContractTests.cs" />
-=======
     <!-- AQ5 headless cancel/timeout protocol tests (rivoli-ai/andy-cli#50) -->
     <Compile Include="Headless/HeadlessAgentRunnerCancelTests.cs" />
     <!-- AQ7 headless stability + regression fixture tests (rivoli-ai/andy-cli#52) -->
     <Compile Include="Headless/HeadlessAgentRunnerStabilityTests.cs" />
->>>>>>> origin/main
+    <!-- AQ8 headless contract validation library (rivoli-ai/andy-cli#54) -->
+    <Compile Include="HeadlessConfig/HeadlessConfigContractTests.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

PR #65 (AQ8 contract library) was merged with unresolved git conflict markers in `tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj`, which broke the build on `main`. This restores it and fixes an order-dependent test failure uncovered in the process.

## Changes

- **Resolve the conflict markers** in the test project file, keeping all three headless test registrations: AQ5 cancel (`HeadlessAgentRunnerCancelTests`), AQ7 stability (`HeadlessAgentRunnerStabilityTests`), and AQ8 contract (`HeadlessConfigContractTests`).
- **Fix a global schema-registry collision.** Both the AQ8 contract library and the AQ1 `HeadlessConfigSchemaTests` built a JSON schema carrying the same `$id` into JsonSchema.Net's process-global `SchemaRegistry`. With xUnit's default parallel execution, whichever registered second threw `Overwriting registered schemas is not permitted`, so the suite failed non-deterministically (the contract tests or the schema tests, depending on order). The schemas contain no internal `$ref`, so the contract library now strips the `$id` before building the schema, keeping its evaluation isolated from the global registry.

## Verification

- `dotnet build Andy.Cli.sln`: succeeds.
- Full suite run 5 times (including fresh builds): deterministic 288 passed, 1 skipped, 0 failed.