### PR TITLE
Isolate AQ1 schema test loader from the global schema registry

### DIFF
--- a/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigSchemaTests.cs
+++ b/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigSchemaTests.cs
@@ -33,10 +33,24 @@ public class HeadlessConfigSchemaTests
         return dir.FullName;
     }
 
-    // JsonSchema.Net registers schemas by $id and throws on re-registration.
-    // Cache the parsed schema so every test shares one instance.
+    // JsonSchema.Net registers any schema carrying an "$id" into a process-global
+    // SchemaRegistry and throws "Overwriting registered schemas is not permitted"
+    // when another component (the HeadlessConfigLoader, the AQ8 contract library)
+    // registers the same $id during the same test run. The schema has no internal
+    // "$ref", so the $id is unused for resolution here; strip it before building so
+    // this loader never touches the global registry. Cache the parsed schema so
+    // every test shares one instance.
     private static readonly Lazy<JsonSchema> s_schema = new(() =>
-        JsonSchema.FromFile(SchemaPath));
+    {
+        var node = JsonNode.Parse(File.ReadAllText(SchemaPath))
+            ?? throw new InvalidOperationException($"Schema at {SchemaPath} parsed to null.");
+        if (node is JsonObject obj)
+        {
+            obj.Remove("$id");
+        }
+        return JsonSerializer.Deserialize<JsonSchema>(node)
+            ?? throw new InvalidOperationException($"Schema at {SchemaPath} deserialized to null.");
+    });
 
     private static JsonSchema LoadSchema() => s_schema.Value;
 


### PR DESCRIPTION
## Summary

Follow-up to #70. The headless test suite was still failing non-deterministically (270/289 vs 288/289 depending on test order) because of a residual global schema-registry collision.

`HeadlessConfigSchemaTests` (AQ1) built the config schema via `JsonSchema.FromFile`, which registers it by `$id` into JsonSchema.Net's process-global `SchemaRegistry`. When another registrant in the same run — `HeadlessConfigLoader` or the AQ8 contract library — had already registered the same `$id`, the second build threw `Overwriting registered schemas is not permitted`, and AQ1's loader had no fallback.

The schema contains no internal `$ref`, so the `$id` is unused for resolution. Strip it before building (matching the fix already applied to the contract library in #70), so this loader never touches the global registry.

## Verification

Full suite run 4 times with fresh builds: deterministic 288 passed, 1 skipped, 0 failed.