### PR TITLE
Bump Andy.Engine to 2026.5.30-rc.33 (SimpleAgent cancellation propagation)

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Andy.Acp.Core" Version="2025.11.18-rc.3" />
-    <PackageReference Include="Andy.Engine" Version="2026.2.10-rc.28" />
+    <PackageReference Include="Andy.Engine" Version="2026.5.30-rc.33" />
     <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />


### PR DESCRIPTION
## Summary

Bumps `Andy.Engine` from `2026.2.10-rc.28` to `2026.5.30-rc.33`, which carries the SimpleAgent fix from andy-engine#4: `ProcessMessageAsync` now propagates `OperationCanceledException` instead of masking a cancellation as a failed result.

This is the root-cause counterpart to the headless cancel protocol (#50): the runner's defensive token check still works, but it now also receives the exception-based cancellation signal it was originally designed around.

## Compatibility

rc.33 depends on `Andy.Llm 2026.5.29-rc.31` — the exact version the CLI already references — so there is no downgrade conflict.

## Verification

- `dotnet restore` / `dotnet build`: clean, no NU1605.
- Full test suite: 288 passed, 1 skipped, 0 failed.
- End-to-end headless run against openrouter `xiaomi/mimo-v2.5`: exit 0.