### PR TITLE
Display version number next to Andy.CLI header

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -11,6 +11,13 @@
     <SelfContained>false</SelfContained>
     <!-- Enable JSON reflection for trimming compatibility -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <!--
+      Default date-based version for the Andy ecosystem. The release workflow
+      (.github/workflows/release.yml) overrides this at publish time via
+      -p:Version. It flows to AssemblyVersion / FileVersion /
+      InformationalVersion and is shown next to the header.
+    -->
+    <Version>2026.5.30</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -1188,12 +1188,9 @@ class Program
                 // Prepare header components
                 var gitInfo = GetGitInfo();
 
-                // Get version from assembly (only in release builds)
-                string version = "";
-                #if RELEASE
-                var assemblyVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-                version = assemblyVersion != null ? $" v{assemblyVersion.Major}.{assemblyVersion.Minor}.{assemblyVersion.Build}" : "";
-                #endif
+                // Get the human-readable application version for display
+                var displayVersion = VersionInfo.ResolveDisplayVersion();
+                var version = string.IsNullOrEmpty(displayVersion) ? "" : $" v{displayVersion}";
 
                 var leftSection = $"Andy CLI{version}";
                 var rightSection = $"[{gitInfo.branch}@{gitInfo.commit}]";

--- a/src/Andy.Cli/VersionInfo.cs
+++ b/src/Andy.Cli/VersionInfo.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Reflection;
+
+namespace Andy.Cli;
+
+/// <summary>
+/// Resolves the human-readable application version for display in the UI.
+/// </summary>
+public static class VersionInfo
+{
+    /// <summary>
+    /// Resolves the display version for the running application.
+    /// Prefers the informational version (which preserves the full string
+    /// including any pre-release suffix) and falls back to the assembly
+    /// version. Build-metadata hashes (anything after a '+') are trimmed so
+    /// the header stays readable.
+    /// </summary>
+    public static string ResolveDisplayVersion()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+        return ResolveDisplayVersion(informational, assembly.GetName().Version);
+    }
+
+    /// <summary>
+    /// Resolves the display version from the supplied informational version
+    /// string and assembly version. Exposed for testing.
+    /// </summary>
+    public static string ResolveDisplayVersion(string? informationalVersion, Version? assemblyVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            // Strip build metadata (e.g. "+abc1234") which is not human-readable.
+            var plus = informationalVersion.IndexOf('+');
+            var trimmed = (plus >= 0 ? informationalVersion.Substring(0, plus) : informationalVersion).Trim();
+            if (trimmed.Length > 0)
+            {
+                return trimmed;
+            }
+        }
+
+        if (assemblyVersion != null)
+        {
+            return $"{assemblyVersion.Major}.{assemblyVersion.Minor}.{assemblyVersion.Build}";
+        }
+
+        return string.Empty;
+    }
+}

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -32,6 +32,7 @@
     <!-- Temporarily exclude test files that need updating for new API -->
     <Compile Remove="**/*.cs" />
     <Compile Include="TestHelpers/TestCompatibilityShims.cs" />
+    <Compile Include="VersionInfoTests.cs" />
     <Compile Include="Commands/ModelCommandTests.cs" />
     <Compile Include="Services/ProviderDetectionServiceTests.cs" />
     <Compile Include="Services/SystemPromptBuilderTests.cs" />

--- a/tests/Andy.Cli.Tests/VersionInfoTests.cs
+++ b/tests/Andy.Cli.Tests/VersionInfoTests.cs
@@ -1,0 +1,60 @@
+using System;
+using Andy.Cli;
+using Xunit;
+
+namespace Andy.Cli.Tests;
+
+public class VersionInfoTests
+{
+    [Fact]
+    public void PrefersInformationalVersion_OverAssemblyVersion()
+    {
+        var result = VersionInfo.ResolveDisplayVersion("2026.5.30", new Version(1, 0, 0, 0));
+        Assert.Equal("2026.5.30", result);
+    }
+
+    [Fact]
+    public void StripsBuildMetadataAfterPlus()
+    {
+        var result = VersionInfo.ResolveDisplayVersion("2026.5.30+abc1234", new Version(1, 0, 0, 0));
+        Assert.Equal("2026.5.30", result);
+    }
+
+    [Fact]
+    public void KeepsPreReleaseSuffix()
+    {
+        var result = VersionInfo.ResolveDisplayVersion("2026.5.30-rc.7", new Version(1, 0, 0, 0));
+        Assert.Equal("2026.5.30-rc.7", result);
+    }
+
+    [Fact]
+    public void TrimsWhitespace()
+    {
+        var result = VersionInfo.ResolveDisplayVersion("  2026.5.30  ", null);
+        Assert.Equal("2026.5.30", result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FallsBackToAssemblyVersion_WhenInformationalIsMissing(string? informational)
+    {
+        var result = VersionInfo.ResolveDisplayVersion(informational, new Version(2026, 5, 30, 0));
+        Assert.Equal("2026.5.30", result);
+    }
+
+    [Fact]
+    public void ReturnsEmpty_WhenNoVersionAvailable()
+    {
+        var result = VersionInfo.ResolveDisplayVersion(null, null);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void ResolvesRunningAssemblyVersion_NonEmpty()
+    {
+        var result = VersionInfo.ResolveDisplayVersion();
+        Assert.False(string.IsNullOrWhiteSpace(result));
+    }
+}


### PR DESCRIPTION
Closes #20

## Summary
The header previously showed a meaningless `v1.0.0` (only in RELEASE builds) because no version property existed in the project file, so the assembly version defaulted to 1.0.0.

This change:
- Adds a sensible date-based default `<Version>2026.5.30</Version>` to `src/Andy.Cli/Andy.Cli.csproj`, matching the Andy ecosystem convention. It flows to AssemblyVersion / FileVersion / InformationalVersion, and the release workflow still overrides it at publish time.
- Adds `VersionInfo.ResolveDisplayVersion()` which reads `AssemblyInformationalVersionAttribute` (preserving any pre-release suffix), trims build metadata after `+` (e.g. the git hash) so the header stays readable, and falls back to the assembly version.
- Updates `Program.cs` to render the resolved version in all build configurations (removing the RELEASE-only guard). The header now shows `Andy CLI v2026.5.30`. Layout/width math is unchanged.

## Verification
- `dotnet build src/Andy.Cli/Andy.Cli.csproj`: build succeeded, 0 warnings, 0 errors.
- `dotnet test tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj`: Passed 297, Failed 0, Skipped 1 (pre-existing skip).
- Added `VersionInfoTests` (registered in the test csproj Compile Include list) covering informational-version preference, build-metadata stripping, pre-release suffix retention, whitespace trimming, assembly-version fallback, empty case, and live runtime resolution.
- Confirmed the built assembly carries InformationalVersion `2026.5.30+<hash>` and AssemblyVersion `2026.5.30.0`; the helper trims the hash, yielding `v2026.5.30` in the header.