### PR TITLE
Add theme selection, persistence, and switch command

### DIFF
--- a/src/Andy.Cli/Commands/ThemeCommand.cs
+++ b/src/Andy.Cli/Commands/ThemeCommand.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Cli.Services;
+using Andy.Cli.Themes;
+
+namespace Andy.Cli.Commands;
+
+/// <summary>
+/// Lists and switches the active UI theme, persisting the choice across sessions.
+/// </summary>
+public class ThemeCommand : ICommand
+{
+    private readonly ThemeMemoryService _themeMemory;
+
+    public string Name => "theme";
+    public string Description => "List and switch the UI theme";
+    public string[] Aliases => new[] { "/theme", "themes" };
+
+    public ThemeCommand() : this(new ThemeMemoryService())
+    {
+    }
+
+    public ThemeCommand(ThemeMemoryService themeMemory)
+    {
+        _themeMemory = themeMemory;
+    }
+
+    public Task<CommandResult> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
+    {
+        if (args.Length == 0)
+        {
+            return Task.FromResult(ListThemes());
+        }
+
+        return Task.FromResult(SwitchTheme(args[0]));
+    }
+
+    private CommandResult ListThemes()
+    {
+        var result = new StringBuilder();
+        result.AppendLine("Available Themes");
+        result.AppendLine("----------------");
+        foreach (var name in Theme.AvailableThemes)
+        {
+            var marker = string.Equals(name, Theme.Current.Name, StringComparison.OrdinalIgnoreCase)
+                ? " (current)"
+                : "";
+            result.AppendLine($"  {name}{marker}");
+        }
+        result.AppendLine();
+        result.AppendLine("Usage: /theme <name>");
+        return CommandResult.CreateSuccess(result.ToString());
+    }
+
+    private CommandResult SwitchTheme(string requested)
+    {
+        var theme = Theme.GetByName(requested);
+        if (theme == null)
+        {
+            var available = string.Join(", ", Theme.AvailableThemes);
+            return CommandResult.Failure(
+                $"Unknown theme: '{requested}'. Available themes: {available}");
+        }
+
+        Theme.Current = theme;
+        _themeMemory.SaveTheme(theme.Name);
+        return CommandResult.CreateSuccess($"Theme switched to '{theme.Name}'.");
+    }
+}

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -155,6 +155,17 @@ class Program
             await HandleCommandLineArgs(args);
             return;
         }
+        // Apply the persisted theme (falling back to an ANDY_THEME env default,
+        // then the built-in dark theme) before the first frame is rendered.
+        var themeMemory = new ThemeMemoryService();
+        var savedThemeName = themeMemory.LoadTheme()
+            ?? Environment.GetEnvironmentVariable("ANDY_THEME");
+        var savedTheme = Andy.Cli.Themes.Theme.GetByName(savedThemeName);
+        if (savedTheme != null)
+        {
+            Andy.Cli.Themes.Theme.Current = savedTheme;
+        }
+
         var caps = Andy.Tui.Backend.Terminal.CapabilityDetector.DetectFromEnvironment();
 
         // Ensure minimum viewport size to prevent crashes
@@ -203,6 +214,7 @@ class Program
             {
                 new InlineCommandHelp.CommandInfo { Name = "model", Description = "Manage AI models (list, switch, info, test)", Aliases = new[] { "m" } },
                 new InlineCommandHelp.CommandInfo { Name = "tools", Description = "Manage and list available tools", Aliases = new[] { "tool", "t" } },
+                new InlineCommandHelp.CommandInfo { Name = "theme", Description = "List and switch the UI theme", Aliases = new[] { "themes" } },
                 new InlineCommandHelp.CommandInfo { Name = "clear", Description = "Clear conversation history", Aliases = Array.Empty<string>() },
                 new InlineCommandHelp.CommandInfo { Name = "help", Description = "Show help information", Aliases = new[] { "?" } },
                 new InlineCommandHelp.CommandInfo { Name = "exit", Description = "Exit the application", Aliases = new[] { "quit", "bye" } }
@@ -313,6 +325,7 @@ class Program
             // Initialize commands
             var modelCommand = new ModelCommand(serviceProvider);
             var toolsCommand = new ToolsCommand(serviceProvider);
+            var themeCommand = new ThemeCommand(themeMemory);
             var commandPalette = new CommandPalette();
 
             Andy.Model.Llm.ILlmProvider? llmProvider = null;
@@ -619,6 +632,21 @@ class Program
                 },
                 new CommandPalette.CommandItem
                 {
+                    Name = "Switch Theme",
+                    Description = "List or change the UI theme",
+                    Category = "UI",
+                    Aliases = new[] { "theme", "themes" },
+                    RequiredParams = new[] { "theme" },
+                    ParameterHint = "Example: dark or light",
+                    GetAvailableOptions = () => Andy.Cli.Themes.Theme.AvailableThemes.ToArray(),
+                    Action = async args =>
+                    {
+                        var result = await themeCommand.ExecuteAsync(args);
+                        feed.AddMarkdownRich(result.Message);
+                    }
+                },
+                new CommandPalette.CommandItem
+                {
                     Name = "Help",
                     Description = "Show help information",
                     Category = "General",
@@ -652,6 +680,9 @@ class Program
                             "- **/model switch <provider>**: Change provider\n" +
                             "- **/model info**: Show current model details\n" +
                             "- **/model test [prompt]**: Test current model\n\n" +
+                            "### Theme Commands:\n" +
+                            "- **/theme**: List available themes and the current one\n" +
+                            "- **/theme <name>**: Switch the UI theme (e.g. dark, light)\n\n" +
                             "### Tool Commands:\n" +
                             "- **/tools list [category]**: List available tools\n" +
                             "- **/tools info <tool_name>**: Show tool details\n" +
@@ -1037,6 +1068,9 @@ class Program
                                         "- **/model switch <provider>**: Change provider\n" +
                                         "- **/model info**: Show current model details\n" +
                                         "- **/model test [prompt]**: Test current model\n\n" +
+                                        "### Theme Commands:\n" +
+                                        "- **/theme**: List available themes and the current one\n" +
+                                        "- **/theme <name>**: Switch the UI theme (e.g. dark, light)\n\n" +
                                         "### Tool Commands:\n" +
                                         "- **/tools list [category]**: List available tools\n" +
                                         "- **/tools info <tool_name>**: Show tool details\n" +
@@ -1050,6 +1084,13 @@ class Program
                                         "- **TextProcessing**: Text manipulation\n" +
                                         "- **System**: System information\n" +
                                         "- **Web**: HTTP and JSON tools");
+                                    return;
+                                }
+                                else if (commandName == "theme" || commandName == "themes")
+                                {
+                                    feed.AddUserMessage(cmd);
+                                    var result = await themeCommand.ExecuteAsync(args);
+                                    feed.AddMarkdownRich(result.Message);
                                     return;
                                 }
                                 else if (commandName == "clear")

--- a/src/Andy.Cli/Services/ThemeMemoryService.cs
+++ b/src/Andy.Cli/Services/ThemeMemoryService.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Andy.Cli.Services;
+
+/// <summary>
+/// Service for remembering the user's selected UI theme across sessions.
+/// </summary>
+public class ThemeMemoryService
+{
+    private readonly string _configPath;
+
+    /// <summary>
+    /// Create a service that persists the selected theme to the default user
+    /// config location (~/.andy/theme-memory.json).
+    /// </summary>
+    public ThemeMemoryService()
+        : this(DefaultConfigPath())
+    {
+    }
+
+    /// <summary>
+    /// Create a service that persists the selected theme to the given file path.
+    /// Primarily intended for testing against a temporary location.
+    /// </summary>
+    public ThemeMemoryService(string configPath)
+    {
+        _configPath = configPath;
+        var dir = Path.GetDirectoryName(_configPath);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+    }
+
+    private static string DefaultConfigPath()
+    {
+        var configDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".andy");
+        Directory.CreateDirectory(configDir);
+        return Path.Combine(configDir, "theme-memory.json");
+    }
+
+    /// <summary>
+    /// Persist the selected theme name.
+    /// </summary>
+    public void SaveTheme(string themeName)
+    {
+        try
+        {
+            var memory = new ThemeMemory
+            {
+                Theme = themeName,
+                LastUsed = DateTime.UtcNow
+            };
+            var json = JsonSerializer.Serialize(memory, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+            File.WriteAllText(_configPath, json);
+        }
+        catch
+        {
+            // Silently fail if we can't save
+        }
+    }
+
+    /// <summary>
+    /// Load the previously selected theme name, or null when none was saved.
+    /// </summary>
+    public string? LoadTheme()
+    {
+        try
+        {
+            if (File.Exists(_configPath))
+            {
+                var json = File.ReadAllText(_configPath);
+                var memory = JsonSerializer.Deserialize<ThemeMemory>(json);
+                return string.IsNullOrWhiteSpace(memory?.Theme) ? null : memory!.Theme;
+            }
+        }
+        catch
+        {
+            // If loading fails, behave as if nothing was saved
+        }
+        return null;
+    }
+
+    private class ThemeMemory
+    {
+        public string Theme { get; set; } = "";
+        public DateTime LastUsed { get; set; }
+    }
+}

--- a/src/Andy.Cli/Themes/Theme.cs
+++ b/src/Andy.Cli/Themes/Theme.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using DL = Andy.Tui.DisplayList;
 
 namespace Andy.Cli.Themes
@@ -7,6 +10,11 @@ namespace Andy.Cli.Themes
     /// </summary>
     public sealed class Theme
     {
+        /// <summary>
+        /// Human-readable, lookup-friendly name for this theme (e.g. "dark", "light").
+        /// </summary>
+        public string Name { get; set; } = "dark";
+
         // Background colors.
         // null = transparent: the terminal's own background (including transparency)
         // shows through. Main surface, header, prompt and dialog backgrounds are
@@ -70,10 +78,93 @@ namespace Andy.Cli.Themes
         /// <summary>
         /// Default dark theme.
         /// </summary>
-        public static Theme Dark { get; } = new Theme();
+        public static Theme Dark { get; } = new Theme { Name = "dark" };
 
         /// <summary>
-        /// Get the current active theme (can be extended for theme switching).
+        /// A light theme suited to terminals with a bright background.
+        /// </summary>
+        public static Theme Light { get; } = new Theme
+        {
+            Name = "light",
+            // Keep main surfaces transparent so the terminal background shows through,
+            // but use darker text/accents that remain legible on a light background.
+            Background = null,
+            HeaderBackground = null,
+            DialogBackground = null,
+            CodeBlockBackground = new DL.Rgb24(235, 235, 240),
+            PromptBackground = null,
+            ToastBackground = new DL.Rgb24(240, 235, 180),
+            StatusLineBackground = new DL.Rgb24(225, 225, 225),
+            KeyHintsBackground = new DL.Rgb24(230, 230, 230),
+
+            Text = new DL.Rgb24(40, 40, 40),
+            TextDim = new DL.Rgb24(110, 110, 110),
+            TextBright = new DL.Rgb24(0, 0, 0),
+
+            Primary = new DL.Rgb24(30, 90, 170),
+            Secondary = new DL.Rgb24(140, 110, 0),
+            Accent = new DL.Rgb24(50, 100, 180),
+
+            Success = new DL.Rgb24(0, 140, 0),
+            Warning = new DL.Rgb24(170, 120, 0),
+            Error = new DL.Rgb24(190, 30, 30),
+            Info = new DL.Rgb24(20, 110, 180),
+
+            Heading = new DL.Rgb24(140, 110, 0),
+            Code = new DL.Rgb24(70, 70, 70),
+            Ghost = new DL.Rgb24(160, 160, 160),
+            Border = new DL.Rgb24(170, 170, 170),
+            Separator = new DL.Rgb24(180, 185, 200),
+            KeyHighlight = new DL.Rgb24(140, 110, 0),
+
+            HeaderTitle = new DL.Rgb24(120, 100, 0),
+            HeaderPath = new DL.Rgb24(60, 90, 120),
+            HeaderGitInfo = new DL.Rgb24(140, 110, 0),
+            HeaderDelimiter = new DL.Rgb24(150, 150, 170),
+
+            SeparatorBase = new DL.Rgb24(120, 130, 150),
+            SeparatorAccent = new DL.Rgb24(50, 100, 180),
+            SeparatorToken = new DL.Rgb24(110, 130, 100),
+
+            Metadata = new DL.Rgb24(60, 100, 150),
+
+            UserLabel = new DL.Rgb24(0, 130, 0),
+            UserText = new DL.Rgb24(30, 90, 30),
+
+            ToolName = new DL.Rgb24(170, 110, 0),
+            ToolRunning = new DL.Rgb24(40, 90, 180),
+            ToolResult = new DL.Rgb24(90, 90, 90),
+        };
+
+        /// <summary>
+        /// Registry of all predefined themes, keyed by their lower-case name.
+        /// </summary>
+        private static readonly Dictionary<string, Theme> Registry =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                [Dark.Name] = Dark,
+                [Light.Name] = Light,
+            };
+
+        /// <summary>
+        /// The names of all available predefined themes, in a stable order.
+        /// </summary>
+        public static IReadOnlyList<string> AvailableThemes { get; } =
+            new[] { Dark.Name, Light.Name };
+
+        /// <summary>
+        /// Look up a predefined theme by name (case-insensitive).
+        /// Returns null when no theme matches.
+        /// </summary>
+        public static Theme? GetByName(string? name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return null;
+            return Registry.TryGetValue(name.Trim(), out var theme) ? theme : null;
+        }
+
+        /// <summary>
+        /// Get the current active theme.
         /// </summary>
         public static Theme Current { get; set; } = Dark;
     }

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -33,6 +33,7 @@
     <Compile Remove="**/*.cs" />
     <Compile Include="TestHelpers/TestCompatibilityShims.cs" />
     <Compile Include="Commands/ModelCommandTests.cs" />
+    <Compile Include="Themes/ThemeSwitchingTests.cs" />
     <Compile Include="Services/ProviderDetectionServiceTests.cs" />
     <Compile Include="Services/SystemPromptBuilderTests.cs" />
     <Compile Include="Services/SystemPromptsTests.cs" />

--- a/tests/Andy.Cli.Tests/Themes/ThemeSwitchingTests.cs
+++ b/tests/Andy.Cli.Tests/Themes/ThemeSwitchingTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Andy.Cli.Commands;
+using Andy.Cli.Services;
+using Andy.Cli.Themes;
+using Xunit;
+
+namespace Andy.Cli.Tests.Themes;
+
+public class ThemeSwitchingTests
+{
+    // ----- Theme lookup by name -----
+
+    [Fact]
+    public void GetByName_KnownName_ReturnsTheme()
+    {
+        var theme = Theme.GetByName("dark");
+        Assert.NotNull(theme);
+        Assert.Equal("dark", theme!.Name);
+        Assert.Same(Theme.Dark, theme);
+    }
+
+    [Theory]
+    [InlineData("DARK")]
+    [InlineData("Dark")]
+    [InlineData("  light  ")]
+    [InlineData("LIGHT")]
+    public void GetByName_IsCaseInsensitiveAndTrims(string name)
+    {
+        var theme = Theme.GetByName(name);
+        Assert.NotNull(theme);
+        Assert.Equal(name.Trim().ToLowerInvariant(), theme!.Name);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("does-not-exist")]
+    public void GetByName_UnknownOrEmpty_ReturnsNull(string? name)
+    {
+        Assert.Null(Theme.GetByName(name));
+    }
+
+    [Fact]
+    public void AvailableThemes_ContainsDarkAndLight()
+    {
+        Assert.Contains("dark", Theme.AvailableThemes);
+        Assert.Contains("light", Theme.AvailableThemes);
+    }
+
+    // ----- Persistence round-trip -----
+
+    [Fact]
+    public void SaveThenLoad_ReturnsSameThemeName()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "andy-theme-test-" + Guid.NewGuid().ToString("N"), "theme-memory.json");
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            service.SaveTheme("light");
+
+            var reloaded = new ThemeMemoryService(path);
+            Assert.Equal("light", reloaded.LoadTheme());
+        }
+        finally
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (dir != null && Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void Load_NoFile_ReturnsNull()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "andy-theme-test-" + Guid.NewGuid().ToString("N"), "theme-memory.json");
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            Assert.Null(service.LoadTheme());
+        }
+        finally
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (dir != null && Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+    }
+
+    // ----- Command behavior -----
+
+    [Fact]
+    public async Task Command_SwitchKnownTheme_SetsCurrentAndPersists()
+    {
+        var original = Theme.Current;
+        var path = Path.Combine(Path.GetTempPath(), "andy-theme-test-" + Guid.NewGuid().ToString("N"), "theme-memory.json");
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            var command = new ThemeCommand(service);
+
+            var result = await command.ExecuteAsync(new[] { "light" });
+
+            Assert.True(result.Success);
+            Assert.Same(Theme.Light, Theme.Current);
+            Assert.Equal("light", service.LoadTheme());
+        }
+        finally
+        {
+            Theme.Current = original;
+            var dir = Path.GetDirectoryName(path);
+            if (dir != null && Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Command_SwitchUnknownTheme_ReportsErrorAndDoesNotChangeCurrent()
+    {
+        var original = Theme.Current;
+        var path = Path.Combine(Path.GetTempPath(), "andy-theme-test-" + Guid.NewGuid().ToString("N"), "theme-memory.json");
+        try
+        {
+            Theme.Current = Theme.Dark;
+            var service = new ThemeMemoryService(path);
+            var command = new ThemeCommand(service);
+
+            var result = await command.ExecuteAsync(new[] { "not-a-theme" });
+
+            Assert.False(result.Success);
+            Assert.Contains("Unknown theme", result.Message);
+            Assert.Same(Theme.Dark, Theme.Current);
+            Assert.Null(service.LoadTheme());
+        }
+        finally
+        {
+            Theme.Current = original;
+            var dir = Path.GetDirectoryName(path);
+            if (dir != null && Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Command_NoArgs_ListsThemesAndMarksCurrent()
+    {
+        var original = Theme.Current;
+        try
+        {
+            Theme.Current = Theme.Dark;
+            var command = new ThemeCommand(new ThemeMemoryService(
+                Path.Combine(Path.GetTempPath(), "andy-theme-test-" + Guid.NewGuid().ToString("N"), "theme-memory.json")));
+
+            var result = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.True(result.Success);
+            Assert.Contains("dark", result.Message);
+            Assert.Contains("light", result.Message);
+            Assert.Contains("(current)", result.Message);
+        }
+        finally
+        {
+            Theme.Current = original;
+        }
+    }
+}


### PR DESCRIPTION
Closes #15

## Summary

Adds user-selectable UI themes for the CLI, with the choice persisted across sessions and applied at startup.

- **Theme registry**: `Theme.GetByName(string)` performs a case-insensitive (and whitespace-trimming) lookup of predefined themes; `Theme.AvailableThemes` exposes the available names. Each theme now carries a `Name`. A second predefined `Light` theme is added alongside the existing `Dark` theme.
- **/theme command** (`ThemeCommand : ICommand`): `/theme` with no args lists available themes and marks the current one; `/theme <name>` switches the active theme (sets `Theme.Current`) and persists it. An unknown name is reported as an error and leaves `Theme.Current` unchanged.
- **Persistence** (`ThemeMemoryService`): saves/loads the selected theme to `~/.andy/theme-memory.json`, mirroring the existing `ModelMemoryService` pattern. A constructor overload accepts a custom path for testing.
- **Startup**: `Program.cs` loads the persisted theme (falling back to the `ANDY_THEME` env var, then the built-in dark theme) and applies it before the first frame. The command is wired into the command palette, inline command help, and the help text.

## Verification

- `dotnet build src/Andy.Cli/Andy.Cli.csproj` — succeeds, 0 warnings, 0 errors.
- `dotnet test tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj` — 303 passed, 1 skipped (pre-existing). Run twice with identical results.
- New tests in `tests/Andy.Cli.Tests/Themes/ThemeSwitchingTests.cs` (15 tests) cover name lookup (valid/invalid/case-insensitive), persistence round-trip, and command behavior (known switch sets Current and persists; unknown reports error and does not change Current). Persistence tests use temp paths and do not touch the real user config.

The interactive TUI was not driven live (not possible in this environment); behavior is covered by unit tests.