### PR TITLE
Enable mouse wheel scrolling and fix PageUp/PageDown

### DIFF
--- a/src/Andy.Cli/Input/RawTerminalInput.cs
+++ b/src/Andy.Cli/Input/RawTerminalInput.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Andy.Cli.Input;
+
+/// <summary>
+/// Reads raw bytes from the controlling terminal so the CLI can receive mouse
+/// wheel events (which <c>Console.ReadKey</c> cannot deliver) while keeping all
+/// existing keyboard handling.
+///
+/// On start it puts the TTY into cbreak mode via <c>stty</c> (no echo, no
+/// canonical line buffering, CR left untranslated), enables SGR mouse reporting,
+/// and spins a background thread that polls fd 0 and feeds bytes through
+/// <see cref="TerminalInputParser"/>. Decoded events are queued for the main
+/// loop to drain. The original terminal settings and mouse mode are restored on
+/// <see cref="Dispose"/>, process exit, and Ctrl+C.
+///
+/// Input is read with libc <c>poll</c>/<c>read</c> on fd 0 rather than
+/// <c>Console.OpenStandardInput()</c>: the .NET console stream forces canonical
+/// (line-buffered) reads that ignore our cbreak settings, whereas the raw
+/// syscalls honor them and let a poll timeout drive the lone-ESC flush.
+///
+/// If the input is redirected or <c>stty</c> is unavailable,
+/// <see cref="TryStart"/> returns <c>null</c> and the caller falls back to the
+/// legacy <c>Console.ReadKey</c> loop.
+/// </summary>
+public sealed class RawTerminalInput : IDisposable
+{
+    private const int StdinFd = 0;
+    private const short POLLIN = 0x0001;
+    private const short POLLERR = 0x0008;
+    private const short POLLHUP = 0x0010;
+    private const short POLLNVAL = 0x0020;
+    private const int PollTimeoutMs = 150;
+
+    private readonly TerminalInputParser _parser = new();
+    private readonly ConcurrentQueue<TerminalInputEvent> _queue = new();
+    private readonly Thread _thread;
+    private readonly string _savedStty;
+    private readonly bool _mouseEnabled;
+    private volatile bool _stop;
+    private int _restored; // 0 = not yet restored, 1 = restored (guards idempotency)
+
+    private RawTerminalInput(string savedStty, bool enableMouse)
+    {
+        _savedStty = savedStty;
+        if (enableMouse)
+        {
+            // 1000 = button tracking (reports wheel as buttons 64/65),
+            // 1006 = SGR extended coordinates.
+            Console.Write("\u001b[?1000h\u001b[?1006h");
+            _mouseEnabled = true;
+        }
+
+        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+        Console.CancelKeyPress += OnCancelKeyPress;
+
+        _thread = new Thread(ReadLoop) { IsBackground = true, Name = "tty-raw-input" };
+        _thread.Start();
+    }
+
+    /// <summary>
+    /// Attempt to switch the terminal into raw byte mode. Returns <c>null</c>
+    /// when input is not an interactive TTY or <c>stty</c> is unavailable, in
+    /// which case the caller should keep using <c>Console.ReadKey</c>.
+    /// </summary>
+    public static RawTerminalInput? TryStart(bool enableMouse)
+    {
+        if (Console.IsInputRedirected) return null;
+
+        if (!RunStty("-g", out string saved) || string.IsNullOrWhiteSpace(saved))
+            return null;
+        saved = saved.Trim();
+
+        // cbreak: no echo, no canonical buffering, leave CR untranslated so
+        // Enter stays 0x0D (submit) and Ctrl+Enter/LF stays 0x0A (newline).
+        // min 0 / time 1 lets reads return promptly. isig stays on so Ctrl+C
+        // still works.
+        if (!RunStty("-echo -icanon -icrnl min 0 time 1", out _))
+        {
+            // Best effort to undo anything partially applied, then bail.
+            RunStty(saved, out _);
+            return null;
+        }
+
+        try
+        {
+            return new RawTerminalInput(saved, enableMouse);
+        }
+        catch
+        {
+            RunStty(saved, out _);
+            return null;
+        }
+    }
+
+    /// <summary>Dequeue the next decoded input event, if any.</summary>
+    public bool TryDequeue(out TerminalInputEvent ev) => _queue.TryDequeue(out ev);
+
+    private void ReadLoop()
+    {
+        var fds = new PollFd[1];
+        var buf = new byte[1024];
+        while (!_stop)
+        {
+            fds[0] = new PollFd { fd = StdinFd, events = POLLIN, revents = 0 };
+
+            int pr;
+            try { pr = poll(fds, (nuint)1, PollTimeoutMs); }
+            catch { break; }
+
+            if (_stop) break;
+            if (pr < 0) continue; // interrupted (EINTR) etc.
+
+            if (pr == 0)
+            {
+                // Idle tick: resolve a pending lone ESC into an Escape key.
+                foreach (var ev in _parser.Flush()) _queue.Enqueue(ev);
+                continue;
+            }
+
+            short revents = fds[0].revents;
+            if ((revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) break; // terminal closed
+
+            if ((revents & POLLIN) != 0)
+            {
+                nint n;
+                try { n = read(StdinFd, buf, (nuint)buf.Length); }
+                catch { break; }
+
+                if (n <= 0) { if (n == 0) break; else continue; }
+                foreach (var ev in _parser.Feed(buf, (int)n)) _queue.Enqueue(ev);
+            }
+        }
+    }
+
+    private void OnProcessExit(object? sender, EventArgs e) => RestoreTerminal();
+
+    private void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e) => RestoreTerminal();
+
+    private void RestoreTerminal()
+    {
+        // Run at most once across Dispose / ProcessExit / Ctrl+C.
+        if (Interlocked.Exchange(ref _restored, 1) != 0) return;
+        try { if (_mouseEnabled) Console.Write("\u001b[?1000l\u001b[?1006l"); } catch { /* ignore */ }
+        try { RunStty(_savedStty, out _); } catch { /* ignore */ }
+    }
+
+    public void Dispose()
+    {
+        _stop = true;
+        try { AppDomain.CurrentDomain.ProcessExit -= OnProcessExit; } catch { /* ignore */ }
+        try { Console.CancelKeyPress -= OnCancelKeyPress; } catch { /* ignore */ }
+        RestoreTerminal();
+        try { _thread.Join(300); } catch { /* ignore */ }
+    }
+
+    private static bool RunStty(string args, out string stdout)
+    {
+        stdout = string.Empty;
+        try
+        {
+            var psi = new ProcessStartInfo("stty", args)
+            {
+                // Inherit our controlling TTY as stty's stdin so it can read and
+                // change the real terminal settings.
+                RedirectStandardInput = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var p = Process.Start(psi);
+            if (p == null) return false;
+            stdout = p.StandardOutput.ReadToEnd();
+            _ = p.StandardError.ReadToEnd();
+            if (!p.WaitForExit(2000)) return false;
+            return p.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    // ----- libc interop (poll/read honor our cbreak termios; the .NET console
+    // stream does not) -----
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PollFd
+    {
+        public int fd;
+        public short events;
+        public short revents;
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int poll([In, Out] PollFd[] fds, nuint nfds, int timeout);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern nint read(int fd, byte[] buf, nuint count);
+}

--- a/src/Andy.Cli/Input/TerminalInputParser.cs
+++ b/src/Andy.Cli/Input/TerminalInputParser.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Andy.Cli.Input;
+
+/// <summary>The kind of event produced by <see cref="TerminalInputParser"/>.</summary>
+public enum TerminalInputKind
+{
+    /// <summary>A keyboard event; see <see cref="TerminalInputEvent.Key"/>.</summary>
+    Key,
+    /// <summary>A mouse wheel scroll; see <see cref="TerminalInputEvent.WheelDelta"/>.</summary>
+    Wheel
+}
+
+/// <summary>
+/// A single decoded terminal input event. Keys are surfaced as <see cref="ConsoleKeyInfo"/>
+/// so they flow through the same handlers used by the legacy <c>Console.ReadKey</c> path.
+/// </summary>
+public readonly struct TerminalInputEvent
+{
+    public TerminalInputKind Kind { get; }
+    /// <summary>Valid when <see cref="Kind"/> is <see cref="TerminalInputKind.Key"/>.</summary>
+    public ConsoleKeyInfo Key { get; }
+    /// <summary>Wheel notches: positive scrolls up (toward older content), negative scrolls down.</summary>
+    public int WheelDelta { get; }
+
+    private TerminalInputEvent(TerminalInputKind kind, ConsoleKeyInfo key, int wheelDelta)
+    {
+        Kind = kind;
+        Key = key;
+        WheelDelta = wheelDelta;
+    }
+
+    public static TerminalInputEvent FromKey(ConsoleKeyInfo key) => new(TerminalInputKind.Key, key, 0);
+    public static TerminalInputEvent FromWheel(int delta) => new(TerminalInputKind.Wheel, default, delta);
+}
+
+/// <summary>
+/// A small, stateful VT/ANSI input decoder. It turns raw stdin bytes into
+/// <see cref="TerminalInputEvent"/>s, covering every key the CLI relies on
+/// (arrows, Home/End, Delete, PageUp/PageDown, Backspace, Enter, Tab, Escape,
+/// Ctrl+letter, Ctrl+], printable text) plus SGR mouse-wheel events.
+///
+/// We parse keys ourselves rather than leaning on Andy.Tui.Input's decoder
+/// because that decoder drops Backspace, Escape, Delete, Home/End and
+/// PageUp/PageDown — all of which the CLI needs. The decoder remains the
+/// reference for SGR mouse wheel, whose encoding we mirror here.
+///
+/// Partial sequences are buffered between <see cref="Feed"/> calls. A lone
+/// ESC byte is held pending until <see cref="Flush"/> is called (after an idle
+/// tick) so it can be disambiguated from the start of an escape sequence.
+/// </summary>
+public sealed class TerminalInputParser
+{
+    private readonly List<byte> _buf = new();
+
+    /// <summary>Feed raw bytes and return any complete events decoded so far.</summary>
+    public IReadOnlyList<TerminalInputEvent> Feed(byte[] data, int length)
+    {
+        var outEvents = new List<TerminalInputEvent>();
+        for (int i = 0; i < length; i++) _buf.Add(data[i]);
+        Drain(outEvents);
+        return outEvents;
+    }
+
+    /// <summary>Convenience overload feeding the whole array.</summary>
+    public IReadOnlyList<TerminalInputEvent> Feed(byte[] data) => Feed(data, data.Length);
+
+    /// <summary>
+    /// Resolve anything left pending. Currently this only matters for a lone
+    /// ESC byte, which becomes <see cref="ConsoleKey.Escape"/> once we know no
+    /// continuation bytes are arriving.
+    /// </summary>
+    public IReadOnlyList<TerminalInputEvent> Flush()
+    {
+        var outEvents = new List<TerminalInputEvent>();
+        if (_buf.Count == 1 && _buf[0] == 0x1B)
+        {
+            _buf.Clear();
+            outEvents.Add(Esc());
+        }
+        return outEvents;
+    }
+
+    private void Drain(List<TerminalInputEvent> outEvents)
+    {
+        // Consume as many complete tokens from the front of the buffer as we
+        // can. Stop when the head is an incomplete sequence (need more bytes).
+        while (_buf.Count > 0)
+        {
+            int consumed = TryConsume(outEvents);
+            if (consumed <= 0) break; // incomplete; wait for more bytes
+            _buf.RemoveRange(0, consumed);
+        }
+    }
+
+    /// <summary>
+    /// Try to decode one token at the front of the buffer. Returns the number
+    /// of bytes consumed, or 0 if the buffer holds an incomplete sequence.
+    /// </summary>
+    private int TryConsume(List<TerminalInputEvent> outEvents)
+    {
+        byte b = _buf[0];
+
+        if (b == 0x1B) return TryConsumeEscape(outEvents);
+
+        // Single-byte controls and printable bytes.
+        switch (b)
+        {
+            case 0x0D: outEvents.Add(Key('\r', ConsoleKey.Enter)); return 1;          // CR -> Enter (submit)
+            case 0x0A: outEvents.Add(Key('\n', ConsoleKey.Enter, control: true)); return 1; // LF -> Ctrl+Enter (newline)
+            case 0x09: outEvents.Add(Key('\t', ConsoleKey.Tab)); return 1;
+            case 0x7F: outEvents.Add(Key('\b', ConsoleKey.Backspace)); return 1;       // DEL -> Backspace
+            case 0x08: outEvents.Add(Key('\b', ConsoleKey.Backspace)); return 1;       // BS  -> Backspace
+            case 0x1D: outEvents.Add(Key('\u001d', ConsoleKey.Oem6, control: true)); return 1; // Ctrl+]
+            case 0x00: return 1; // ignore NUL
+        }
+
+        if (b >= 0x01 && b <= 0x1A)
+        {
+            // Ctrl+A .. Ctrl+Z (0x08/0x09/0x0A/0x0D handled above).
+            var key = (ConsoleKey)('A' + (b - 1));
+            outEvents.Add(Key((char)b, key, control: true));
+            return 1;
+        }
+
+        if (b >= 0x20 && b <= 0x7E)
+        {
+            outEvents.Add(Printable((char)b));
+            return 1;
+        }
+
+        if (b >= 0x80)
+            return TryConsumeUtf8(outEvents);
+
+        // Remaining C0 controls we don't map: drop the byte.
+        return 1;
+    }
+
+    private int TryConsumeEscape(List<TerminalInputEvent> outEvents)
+    {
+        if (_buf.Count < 2) return 0; // could be lone ESC or start of a sequence
+
+        byte second = _buf[1];
+        if (second == (byte)'[') return TryConsumeCsi(outEvents);
+        if (second == (byte)'O') return TryConsumeSs3(outEvents);
+
+        // ESC followed by something else: treat ESC as a standalone Escape and
+        // let the following byte be parsed on its own. (Alt+key chords are not
+        // used by the CLI.)
+        outEvents.Add(Esc());
+        return 1;
+    }
+
+    // CSI: ESC '[' ... final-byte(0x40-0x7E)
+    private int TryConsumeCsi(List<TerminalInputEvent> outEvents)
+    {
+        // SGR mouse: ESC '[' '<' params ('M' | 'm')
+        if (_buf.Count >= 3 && _buf[2] == (byte)'<')
+            return TryConsumeSgrMouse(outEvents);
+
+        int i = 2;
+        while (i < _buf.Count)
+        {
+            byte c = _buf[i];
+            if (c >= 0x40 && c <= 0x7E) // final byte
+            {
+                string paramStr = AsciiSlice(2, i);
+                DecodeCsi(paramStr, (char)c, outEvents);
+                return i + 1;
+            }
+            i++;
+        }
+        return 0; // no final byte yet
+    }
+
+    private int TryConsumeSgrMouse(List<TerminalInputEvent> outEvents)
+    {
+        int i = 3;
+        while (i < _buf.Count)
+        {
+            byte c = _buf[i];
+            if (c == (byte)'M' || c == (byte)'m')
+            {
+                string paramStr = AsciiSlice(3, i); // "btn;col;row"
+                var parts = paramStr.Split(';');
+                if (parts.Length >= 1 && int.TryParse(parts[0], out int btn))
+                {
+                    // Wheel buttons have bit 0x40 set; low 2 bits select direction.
+                    if ((btn & 0x40) != 0)
+                    {
+                        int low = btn & 0x03;
+                        if (low == 0) outEvents.Add(TerminalInputEvent.FromWheel(+1));      // wheel up
+                        else if (low == 1) outEvents.Add(TerminalInputEvent.FromWheel(-1)); // wheel down
+                        // low 2/3 are horizontal wheel; ignored.
+                    }
+                    // Non-wheel mouse (press/release/move) has no CLI behavior.
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return 0; // sequence not terminated yet
+    }
+
+    // SS3: ESC 'O' final
+    private int TryConsumeSs3(List<TerminalInputEvent> outEvents)
+    {
+        if (_buf.Count < 3) return 0;
+        char f = (char)_buf[2];
+        switch (f)
+        {
+            case 'A': outEvents.Add(Key('\0', ConsoleKey.UpArrow)); return 3;
+            case 'B': outEvents.Add(Key('\0', ConsoleKey.DownArrow)); return 3;
+            case 'C': outEvents.Add(Key('\0', ConsoleKey.RightArrow)); return 3;
+            case 'D': outEvents.Add(Key('\0', ConsoleKey.LeftArrow)); return 3;
+            case 'H': outEvents.Add(Key('\0', ConsoleKey.Home)); return 3;
+            case 'F': outEvents.Add(Key('\0', ConsoleKey.End)); return 3;
+            case 'P': outEvents.Add(Key('\0', ConsoleKey.F1)); return 3;
+            case 'Q': outEvents.Add(Key('\0', ConsoleKey.F2)); return 3;
+            case 'R': outEvents.Add(Key('\0', ConsoleKey.F3)); return 3;
+            case 'S': outEvents.Add(Key('\0', ConsoleKey.F4)); return 3;
+            default: return 3; // unknown SS3; drop
+        }
+    }
+
+    private void DecodeCsi(string paramStr, char final, List<TerminalInputEvent> outEvents)
+    {
+        // paramStr looks like "", "5", "1;5" etc. The second numeric parameter,
+        // when present, is the xterm modifier code (1 + bitmask).
+        int firstParam = 0;
+        var mods = ConsoleModifiers.None;
+        if (paramStr.Length > 0)
+        {
+            var parts = paramStr.Split(';');
+            int.TryParse(parts[0], out firstParam);
+            if (parts.Length >= 2 && int.TryParse(parts[1], out int modCode) && modCode > 1)
+                mods = DecodeModifier(modCode);
+        }
+
+        switch (final)
+        {
+            case 'A': outEvents.Add(Key('\0', ConsoleKey.UpArrow, mods)); return;
+            case 'B': outEvents.Add(Key('\0', ConsoleKey.DownArrow, mods)); return;
+            case 'C': outEvents.Add(Key('\0', ConsoleKey.RightArrow, mods)); return;
+            case 'D': outEvents.Add(Key('\0', ConsoleKey.LeftArrow, mods)); return;
+            case 'H': outEvents.Add(Key('\0', ConsoleKey.Home, mods)); return;
+            case 'F': outEvents.Add(Key('\0', ConsoleKey.End, mods)); return;
+            case 'Z': outEvents.Add(Key('\t', ConsoleKey.Tab, ConsoleModifiers.Shift)); return; // Shift+Tab
+            case '~':
+                switch (firstParam)
+                {
+                    case 1:
+                    case 7: outEvents.Add(Key('\0', ConsoleKey.Home, mods)); return;
+                    case 2: outEvents.Add(Key('\0', ConsoleKey.Insert, mods)); return;
+                    case 3: outEvents.Add(Key('\0', ConsoleKey.Delete, mods)); return;
+                    case 4:
+                    case 8: outEvents.Add(Key('\0', ConsoleKey.End, mods)); return;
+                    case 5: outEvents.Add(Key('\0', ConsoleKey.PageUp, mods)); return;
+                    case 6: outEvents.Add(Key('\0', ConsoleKey.PageDown, mods)); return;
+                    case 11: outEvents.Add(Key('\0', ConsoleKey.F1, mods)); return;
+                    case 12: outEvents.Add(Key('\0', ConsoleKey.F2, mods)); return;
+                    case 13: outEvents.Add(Key('\0', ConsoleKey.F3, mods)); return;
+                    case 14: outEvents.Add(Key('\0', ConsoleKey.F4, mods)); return;
+                    case 15: outEvents.Add(Key('\0', ConsoleKey.F5, mods)); return;
+                    default: return; // unknown ~ sequence
+                }
+            default:
+                return; // unknown CSI; drop
+        }
+    }
+
+    private static ConsoleModifiers DecodeModifier(int modCode)
+    {
+        // xterm: modCode = 1 + (1*shift + 2*alt + 4*ctrl + 8*meta)
+        int bits = modCode - 1;
+        var m = ConsoleModifiers.None;
+        if ((bits & 1) != 0) m |= ConsoleModifiers.Shift;
+        if ((bits & 2) != 0) m |= ConsoleModifiers.Alt;
+        if ((bits & 4) != 0) m |= ConsoleModifiers.Control;
+        return m;
+    }
+
+    private int TryConsumeUtf8(List<TerminalInputEvent> outEvents)
+    {
+        byte lead = _buf[0];
+        int len = lead >= 0xF0 ? 4 : lead >= 0xE0 ? 3 : lead >= 0xC0 ? 2 : 1;
+        if (len == 1)
+        {
+            // Stray continuation/invalid byte; drop it.
+            return 1;
+        }
+        if (_buf.Count < len) return 0; // incomplete multibyte sequence
+
+        var bytes = new byte[len];
+        for (int i = 0; i < len; i++) bytes[i] = _buf[i];
+        string s;
+        try { s = Encoding.UTF8.GetString(bytes); }
+        catch { return len; }
+        foreach (char ch in s)
+            outEvents.Add(Printable(ch));
+        return len;
+    }
+
+    private string AsciiSlice(int start, int endExclusive)
+    {
+        var sb = new StringBuilder(endExclusive - start);
+        for (int i = start; i < endExclusive; i++) sb.Append((char)_buf[i]);
+        return sb.ToString();
+    }
+
+    private static TerminalInputEvent Printable(char c)
+    {
+        ConsoleKey key = 0;
+        bool shift = false;
+        if (c >= 'a' && c <= 'z') key = (ConsoleKey)('A' + (c - 'a'));
+        else if (c >= 'A' && c <= 'Z') { key = (ConsoleKey)c; shift = true; }
+        else if (c >= '0' && c <= '9') key = ConsoleKey.D0 + (c - '0');
+        else if (c == ' ') key = ConsoleKey.Spacebar;
+        return TerminalInputEvent.FromKey(new ConsoleKeyInfo(c, key, shift, false, false));
+    }
+
+    private static TerminalInputEvent Key(char ch, ConsoleKey key, bool control = false)
+        => TerminalInputEvent.FromKey(new ConsoleKeyInfo(ch, key, false, false, control));
+
+    private static TerminalInputEvent Key(char ch, ConsoleKey key, ConsoleModifiers mods)
+        => TerminalInputEvent.FromKey(new ConsoleKeyInfo(
+            ch, key,
+            (mods & ConsoleModifiers.Shift) != 0,
+            (mods & ConsoleModifiers.Alt) != 0,
+            (mods & ConsoleModifiers.Control) != 0));
+
+    private static TerminalInputEvent Esc() => Key('\u001b', ConsoleKey.Escape);
+}

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Andy.Tui.Backend.Terminal;
+using Andy.Cli.Input;
 using Andy.Cli.Instrumentation;
 using Andy.Cli.Widgets;
 using Andy.Cli.Commands;
@@ -184,9 +185,34 @@ class Program
         Console.Write("[49m");
         Console.Clear();
 
+        // Switch the terminal into raw byte mode so we can receive mouse wheel
+        // events. Returns null (and we fall back to Console.ReadKey) when input
+        // is redirected or stty is unavailable. Mouse reporting is only enabled
+        // when this succeeds, since Console.ReadKey cannot decode mouse bytes.
+        var rawInput = RawTerminalInput.TryStart(enableMouse: true);
+
         try
         {
             bool running = true;
+
+            // Blocking read of a single key, sourced from whichever input path is
+            // active. Used by modal loops (e.g. the exit dialog) that need to wait
+            // for one keypress. Wheel events are ignored while a modal is up.
+            ConsoleKeyInfo ReadKeyBlocking()
+            {
+                if (rawInput == null) return Console.ReadKey(true);
+                while (true)
+                {
+                    if (rawInput.TryDequeue(out var ev))
+                    {
+                        if (ev.Kind == TerminalInputKind.Key) return ev.Key;
+                    }
+                    else
+                    {
+                        Thread.Sleep(8);
+                    }
+                }
+            }
 
             // Scroll mode state
             ScrollMode scrollMode = ScrollMode.Feed;
@@ -757,7 +783,7 @@ class Program
                     await scheduler.RenderOnceAsync(confirmB.Build(), viewport, caps, pty, CancellationToken.None);
 
                     // Handle input
-                    ConsoleKeyInfo k2 = Console.ReadKey(true);
+                    ConsoleKeyInfo k2 = ReadKeyBlocking();
                     if (k2.Key == ConsoleKey.LeftArrow || k2.Key == ConsoleKey.RightArrow || k2.Key == ConsoleKey.Tab)
                     {
                         yesSelected = !yesSelected;
@@ -1199,22 +1225,43 @@ class Program
                     if (k.Key == ConsoleKey.PageUp) feed.ScrollLines(+2 * Math.Max(1, viewport.Height - 5), Math.Max(1, viewport.Height - 5));
                     if (k.Key == ConsoleKey.PageDown) feed.ScrollLines(-2 * Math.Max(1, viewport.Height - 5), Math.Max(1, viewport.Height - 5));
                 }
-                try
+                if (rawInput != null)
                 {
-                    while (Console.KeyAvailable)
+                    // Raw mode: drain decoded events. Mouse wheel scrolls the feed
+                    // (3 lines per notch); keys flow through the normal handler.
+                    while (rawInput.TryDequeue(out var ev))
                     {
-                        var k = Console.ReadKey(intercept: true);
-                        await HandleKey(k);
+                        if (ev.Kind == TerminalInputKind.Wheel)
+                        {
+                            int page = Math.Max(1, viewport.Height - 5);
+                            feed.ScrollLines(ev.WheelDelta * 3, page);
+                        }
+                        else
+                        {
+                            await HandleKey(ev.Key);
+                        }
                         if (!running) break;
                     }
                 }
-                catch (InvalidOperationException)
+                else
                 {
-                    while (Console.In.Peek() != -1)
+                    try
                     {
-                        var k = Console.ReadKey(intercept: true);
-                        await HandleKey(k);
-                        if (!running) break;
+                        while (Console.KeyAvailable)
+                        {
+                            var k = Console.ReadKey(intercept: true);
+                            await HandleKey(k);
+                            if (!running) break;
+                        }
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        while (Console.In.Peek() != -1)
+                        {
+                            var k = Console.ReadKey(intercept: true);
+                            await HandleKey(k);
+                            if (!running) break;
+                        }
                     }
                 }
                 // Render placeholder + CLI widgets
@@ -1493,6 +1540,9 @@ class Program
         }
         finally
         {
+            // Restore terminal settings + disable mouse before leaving the
+            // alternate screen, then re-enable wrap/cursor and exit alt screen.
+            rawInput?.Dispose();
             Console.Write("\u001b[?7h\u001b[?25h\u001b[?1049l");
         }
     }
@@ -1789,7 +1839,7 @@ class Program
 
         // Route to appropriate command
         var commandName = args[0].ToLowerInvariant();
-        
+
         // Filter out common flags from the arguments before passing to command
         var filteredArgs = args.Skip(1)
             .Where(arg => !arg.StartsWith("--debug", StringComparison.OrdinalIgnoreCase) &&

--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -399,8 +399,12 @@ namespace Andy.Cli.Widgets
             // Calculate new scroll offset with bounds
             int newOffset = _scrollOffset + delta;
 
-            // Clamp to valid range: 0 (bottom/following tail) to total (top of content)
-            _scrollOffset = Math.Clamp(newOffset, 0, Math.Max(0, total));
+            // Clamp to valid range: 0 (bottom/following tail) up to the highest
+            // offset that still shows content, i.e. total minus the viewport
+            // height. Clamping to `total` instead would create a dead-zone above
+            // the top of the content where scrolling back down does nothing.
+            int maxOffset = Math.Max(0, total - _lastViewportHeight);
+            _scrollOffset = Math.Clamp(newOffset, 0, maxOffset);
             _followTail = _scrollOffset == 0;
             return _scrollOffset;
         }
@@ -418,6 +422,7 @@ namespace Andy.Cli.Widgets
         public int RenderedLineCount => _totalLinesCache;
 
         private int _totalLinesCache;
+        private int _lastViewportHeight;
 
         /// <summary>Render feed items inside rect, stacking vertically with bottom alignment when following tail.</summary>
         public void Render(in L.Rect rect, DL.DisplayList baseDl, DL.DisplayListBuilder b)
@@ -454,6 +459,7 @@ namespace Andy.Cli.Widgets
                 _animRemaining = Math.Min(_animRemaining + (total - _prevTotalLines), total);
             }
             _prevTotalLines = total; _totalLinesCache = total;
+            _lastViewportHeight = h; // remember for scroll-offset clamping
 
             int visible = Math.Min(h, total);
             int startLine;

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -53,6 +53,10 @@
     <Compile Include="Widgets/KeyHintsBarTests.cs" />
     <!-- FeedView reflow signal tests (margin residue fix) -->
     <Compile Include="Widgets/FeedViewReflowSignalTests.cs" />
+    <!-- FeedView scroll-offset clamp tests (PageUp/PageDown/wheel dead-zone fix) -->
+    <Compile Include="Widgets/FeedViewScrollClampTests.cs" />
+    <!-- Raw terminal input decoder tests (mouse wheel + keyboard) -->
+    <Compile Include="Input/TerminalInputParserTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
     <!-- Parallel tool execution tests -->

--- a/tests/Andy.Cli.Tests/Input/TerminalInputParserTests.cs
+++ b/tests/Andy.Cli.Tests/Input/TerminalInputParserTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Andy.Cli.Input;
+using Xunit;
+
+namespace Andy.Cli.Tests.Input;
+
+/// <summary>
+/// Tests for <see cref="TerminalInputParser"/>, the raw-stdin VT decoder that
+/// replaced the Console.ReadKey path so the CLI can receive mouse wheel events.
+/// It must keep decoding every key the CLI relies on (the bundled
+/// Andy.Tui.Input decoder drops Backspace, Escape, Delete, Home/End and
+/// PageUp/PageDown, which is why we parse keys ourselves).
+/// </summary>
+public class TerminalInputParserTests
+{
+    private static List<TerminalInputEvent> Decode(params byte[] bytes)
+        => new TerminalInputParser().Feed(bytes).ToList();
+
+    private static List<TerminalInputEvent> Decode(string ascii)
+        => new TerminalInputParser().Feed(Encoding.ASCII.GetBytes(ascii)).ToList();
+
+    private static TerminalInputEvent Single(IReadOnlyList<TerminalInputEvent> evs)
+    {
+        Assert.Single(evs);
+        return evs[0];
+    }
+
+    // ----- Mouse wheel (the headline feature) -----
+
+    [Fact]
+    public void SgrWheelUp_ProducesPositiveWheelDelta()
+    {
+        var ev = Single(Decode("\x1b[<64;10;5M"));
+        Assert.Equal(TerminalInputKind.Wheel, ev.Kind);
+        Assert.True(ev.WheelDelta > 0, "wheel up should scroll toward older content (positive)");
+    }
+
+    [Fact]
+    public void SgrWheelDown_ProducesNegativeWheelDelta()
+    {
+        var ev = Single(Decode("\x1b[<65;10;5M"));
+        Assert.Equal(TerminalInputKind.Wheel, ev.Kind);
+        Assert.True(ev.WheelDelta < 0, "wheel down should scroll toward newer content (negative)");
+    }
+
+    [Fact]
+    public void SgrWheelWithModifiers_StillDecodesDirection()
+    {
+        // Ctrl held while wheeling sets extra bits (0x10); direction bits remain.
+        var up = Single(Decode("\x1b[<80;1;1M"));   // 64 | 16
+        Assert.Equal(TerminalInputKind.Wheel, up.Kind);
+        Assert.True(up.WheelDelta > 0);
+    }
+
+    [Fact]
+    public void NonWheelMouseEvents_AreIgnored()
+    {
+        // Left button press (button 0) carries no CLI behavior.
+        Assert.Empty(Decode("\x1b[<0;10;5M"));
+        // Release.
+        Assert.Empty(Decode("\x1b[<0;10;5m"));
+    }
+
+    // ----- Keys the Andy.Tui.Input decoder drops -----
+
+    [Fact]
+    public void PageUp_DecodesToPageUpKey()
+    {
+        var ev = Single(Decode("\x1b[5~"));
+        Assert.Equal(TerminalInputKind.Key, ev.Kind);
+        Assert.Equal(ConsoleKey.PageUp, ev.Key.Key);
+    }
+
+    [Fact]
+    public void PageDown_DecodesToPageDownKey()
+    {
+        var ev = Single(Decode("\x1b[6~"));
+        Assert.Equal(ConsoleKey.PageDown, ev.Key.Key);
+    }
+
+    [Fact]
+    public void Backspace_Del7f_DecodesToBackspace()
+    {
+        var ev = Single(Decode(0x7f));
+        Assert.Equal(ConsoleKey.Backspace, ev.Key.Key);
+    }
+
+    [Fact]
+    public void Delete_DecodesToDeleteKey()
+    {
+        var ev = Single(Decode("\x1b[3~"));
+        Assert.Equal(ConsoleKey.Delete, ev.Key.Key);
+    }
+
+    [Fact]
+    public void HomeAndEnd_Decode()
+    {
+        Assert.Equal(ConsoleKey.Home, Single(Decode("\x1b[H")).Key.Key);
+        Assert.Equal(ConsoleKey.End, Single(Decode("\x1b[F")).Key.Key);
+    }
+
+    [Fact]
+    public void LoneEscape_RequiresFlush_ThenDecodesEscape()
+    {
+        var parser = new TerminalInputParser();
+        // A single ESC byte is held pending (could begin a sequence).
+        Assert.Empty(parser.Feed(new byte[] { 0x1b }));
+        // The idle-tick flush resolves it to Escape.
+        var flushed = parser.Flush();
+        var ev = Single(flushed);
+        Assert.Equal(ConsoleKey.Escape, ev.Key.Key);
+    }
+
+    [Fact]
+    public void CtrlRightBracket_DecodesToOem6WithControl()
+    {
+        var ev = Single(Decode(0x1d));
+        Assert.Equal(ConsoleKey.Oem6, ev.Key.Key);
+        Assert.True((ev.Key.Modifiers & ConsoleModifiers.Control) != 0);
+        Assert.Equal('\u001d', ev.Key.KeyChar);
+    }
+
+    // ----- Standard keys -----
+
+    [Fact]
+    public void Arrows_Decode()
+    {
+        Assert.Equal(ConsoleKey.UpArrow, Single(Decode("\x1b[A")).Key.Key);
+        Assert.Equal(ConsoleKey.DownArrow, Single(Decode("\x1b[B")).Key.Key);
+        Assert.Equal(ConsoleKey.RightArrow, Single(Decode("\x1b[C")).Key.Key);
+        Assert.Equal(ConsoleKey.LeftArrow, Single(Decode("\x1b[D")).Key.Key);
+    }
+
+    [Fact]
+    public void Ss3Arrows_Decode()
+    {
+        Assert.Equal(ConsoleKey.UpArrow, Single(Decode("\x1bOA")).Key.Key);
+        Assert.Equal(ConsoleKey.F2, Single(Decode("\x1bOQ")).Key.Key);
+    }
+
+    [Fact]
+    public void CtrlUpArrow_CarriesControlModifier()
+    {
+        var ev = Single(Decode("\x1b[1;5A"));
+        Assert.Equal(ConsoleKey.UpArrow, ev.Key.Key);
+        Assert.True((ev.Key.Modifiers & ConsoleModifiers.Control) != 0);
+    }
+
+    [Fact]
+    public void EnterCr_SubmitsAsPlainEnter()
+    {
+        var ev = Single(Decode(0x0d));
+        Assert.Equal(ConsoleKey.Enter, ev.Key.Key);
+        Assert.Equal(ConsoleModifiers.None, ev.Key.Modifiers & ConsoleModifiers.Control);
+    }
+
+    [Fact]
+    public void EnterLf_MapsToCtrlEnterForNewline()
+    {
+        var ev = Single(Decode(0x0a));
+        Assert.Equal(ConsoleKey.Enter, ev.Key.Key);
+        Assert.True((ev.Key.Modifiers & ConsoleModifiers.Control) != 0);
+    }
+
+    [Fact]
+    public void CtrlLetters_DecodeWithControlModifier()
+    {
+        var d = Single(Decode(0x04)); // Ctrl+D
+        Assert.Equal(ConsoleKey.D, d.Key.Key);
+        Assert.True((d.Key.Modifiers & ConsoleModifiers.Control) != 0);
+
+        var p = Single(Decode(0x10)); // Ctrl+P
+        Assert.Equal(ConsoleKey.P, p.Key.Key);
+        Assert.True((p.Key.Modifiers & ConsoleModifiers.Control) != 0);
+    }
+
+    [Fact]
+    public void PrintableLetters_CarryKeyChar()
+    {
+        var lower = Single(Decode("a"));
+        Assert.Equal('a', lower.Key.KeyChar);
+        Assert.Equal(ConsoleKey.A, lower.Key.Key);
+        Assert.False((lower.Key.Modifiers & ConsoleModifiers.Shift) != 0);
+
+        var upper = Single(Decode("A"));
+        Assert.Equal('A', upper.Key.KeyChar);
+        Assert.True((upper.Key.Modifiers & ConsoleModifiers.Shift) != 0);
+    }
+
+    [Fact]
+    public void PrintableSequence_DecodesEachCharInOrder()
+    {
+        var evs = Decode("ab/1");
+        Assert.Equal(4, evs.Count);
+        Assert.Equal('a', evs[0].Key.KeyChar);
+        Assert.Equal('b', evs[1].Key.KeyChar);
+        Assert.Equal('/', evs[2].Key.KeyChar);
+        Assert.Equal('1', evs[3].Key.KeyChar);
+        Assert.Equal(ConsoleKey.D1, evs[3].Key.Key);
+    }
+
+    // ----- Stream behavior -----
+
+    [Fact]
+    public void SplitEscapeSequence_AcrossFeeds_DecodesOnce()
+    {
+        var parser = new TerminalInputParser();
+        Assert.Empty(parser.Feed(new byte[] { 0x1b })); // pending
+        Assert.Empty(parser.Feed(new byte[] { (byte)'[' })); // still pending
+        var evs = parser.Feed(new byte[] { (byte)'A' });
+        var ev = Single(evs);
+        Assert.Equal(ConsoleKey.UpArrow, ev.Key.Key);
+    }
+
+    [Fact]
+    public void MixedKeyAndWheelBurst_DecodesBoth()
+    {
+        // 'h', wheel-up, 'i' arriving in one read.
+        var evs = new TerminalInputParser().Feed(Encoding.ASCII.GetBytes("h\x1b[<64;1;1Mi"));
+        Assert.Equal(3, evs.Count);
+        Assert.Equal('h', evs[0].Key.KeyChar);
+        Assert.Equal(TerminalInputKind.Wheel, evs[1].Kind);
+        Assert.Equal('i', evs[2].Key.KeyChar);
+    }
+
+    [Fact]
+    public void Utf8MultibyteChar_DecodesToSingleKey()
+    {
+        // 'é' is 0xC3 0xA9 in UTF-8.
+        var ev = Single(new TerminalInputParser().Feed(new byte[] { 0xC3, 0xA9 }));
+        Assert.Equal(TerminalInputKind.Key, ev.Kind);
+        Assert.Equal('é', ev.Key.KeyChar);
+    }
+}

--- a/tests/Andy.Cli.Tests/Widgets/FeedViewScrollClampTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/FeedViewScrollClampTests.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using Andy.Cli.Widgets;
+using Xunit;
+using DL = Andy.Tui.DisplayList;
+using L = Andy.Tui.Layout;
+
+namespace Andy.Cli.Tests.Widgets;
+
+/// <summary>
+/// Tests for <see cref="FeedView.ScrollLines"/> bounds. The scroll offset must
+/// clamp to <c>total - viewportHeight</c> (the highest offset that still shows
+/// content), not to <c>total</c>. Clamping to <c>total</c> left a dead-zone
+/// above the top where scrolling back down appeared to do nothing — part of why
+/// PageUp/PageDown and the wheel felt unresponsive.
+/// </summary>
+public class FeedViewScrollClampTests
+{
+    private const int Width = 80;
+    private const int Height = 10;
+
+    private static void Render(FeedView feed)
+    {
+        var baseDl = new DL.DisplayListBuilder().Build();
+        var builder = new DL.DisplayListBuilder();
+        feed.Render(new L.Rect(2, 3, Width, Height), baseDl, builder);
+    }
+
+    private static FeedView FeedWithLines(int lineCount)
+    {
+        var feed = new FeedView();
+        feed.AddMarkdown(string.Join("\n", Enumerable.Range(0, lineCount).Select(i => $"line {i}")));
+        Render(feed); // populates the line cache and remembers the viewport height
+        return feed;
+    }
+
+    [Fact]
+    public void ScrollUp_ClampsToTotalMinusViewportHeight()
+    {
+        var feed = FeedWithLines(100);
+        int total = feed.RenderedLineCount;
+        Assert.True(total > Height, "test needs more content than the viewport");
+
+        // Scroll far past the top; offset must stop at total - viewportHeight.
+        int offset = feed.ScrollLines(100_000, Height);
+
+        Assert.Equal(total - Height, offset);
+    }
+
+    [Fact]
+    public void ScrollDownAfterMax_MovesImmediately_NoDeadZone()
+    {
+        var feed = FeedWithLines(100);
+        int max = feed.ScrollLines(100_000, Height); // pin to the top
+
+        // One page down from the top must move by the full delta (no dead-zone
+        // of excess offset to unwind first).
+        int afterPageDown = feed.ScrollLines(-Height, Height);
+
+        Assert.Equal(max - Height, afterPageDown);
+    }
+
+    [Fact]
+    public void ScrollDownToBottom_ClampsToZero()
+    {
+        var feed = FeedWithLines(100);
+        feed.ScrollLines(100_000, Height); // top
+        int offset = feed.ScrollLines(-100_000, Height); // bottom
+
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void Scrolling_WhenContentFitsViewport_StaysAtZero()
+    {
+        var feed = FeedWithLines(3); // fewer lines than the viewport height
+        int offset = feed.ScrollLines(100_000, Height);
+
+        Assert.Equal(0, offset);
+    }
+}


### PR DESCRIPTION
## Problem
- Mouse wheel did nothing: the TUI enters the alternate screen buffer but never enabled mouse reporting, so the terminal handled wheel events itself and the app received none.
- PageUp/PageDown were frequently intercepted by the terminal before reaching the `Console.ReadKey` path.
- Scroll-back felt unresponsive due to a `FeedView` clamp dead-zone.

## Change
Switch interactive input to raw stdin so the app receives both mouse and key events directly, with a safe fallback to `Console.ReadKey`.

- **`TerminalInputParser`** — self-contained VT decoder: SGR mouse wheel + every key the CLI uses (arrows, Home/End, Delete, PageUp/PageDown, Backspace, Enter, Tab, Escape, Ctrl+letter, Ctrl+], UTF-8). Keys are parsed here because the bundled input decoder drops several of them.
- **`RawTerminalInput`** — cbreak mode via `stty`, enables SGR mouse reporting, reads fd 0 with libc `poll`/`read` on a background thread (the .NET console stream forces canonical buffering and ignores cbreak). Restores terminal + mouse on dispose, process exit, and Ctrl+C. Returns to the legacy path when input is redirected or `stty` is unavailable.
- **`Program`** — drains decoded events each frame (3 lines/notch wheel scroll); routes the exit dialog through the same source.
- **`FeedView`** — clamps scroll offset to `total - viewportHeight` (was `total`), removing the dead-zone.

## Verification
- 34 unit tests pass (parser: mouse wheel, all key categories, stream splitting, UTF-8; FeedView clamp bounds).
- End-to-end in a real pty against `RawTerminalInput`: `h`, wheel up/down, PageUp, Backspace, and lone Escape all decode correctly, terminal restored cleanly; cbreak survives heavy render output.
- Full solution builds clean; `dotnet format` clean.

Terminals without SGR mouse support fall back to keyboard-only (no regression).