### PR TITLE
Force full repaint on scroll to clear margin residue

### DIFF
--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -1463,13 +1463,16 @@ class Program
                 foreach (var op in overlay.Build().Ops) AppendOpaque(op, builder);
 
                 // The renderer only repaints cells it draws, so with transparent
-                // backgrounds the unmanaged left margin / gap rows can reveal stale
+                // backgrounds the unmanaged left margin / gap cells can reveal stale
                 // "prior output" left in the terminal. Whenever feed content reflows
-                // (items added/removed, line count or scroll change), force the next
-                // frame to be a full clear + repaint (ESC[2J) so that residue is wiped.
-                // (Scroll offset is intentionally excluded: scrolling only changes the
-                // diff-managed feed area, not the margin, so it needs no full repaint.)
-                int reflowSig = HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, (int)scrollMode);
+                // (items added/removed, line count change) OR the user scrolls, force
+                // the next frame to be a full clear + repaint (ESC[2J) so that residue
+                // is wiped. Scrolling must be included: it shifts content and leaves
+                // stale glyphs (e.g. a lone "." or "n") in the margin/gap columns that
+                // the diff renderer never overwrites. Manual scrolling changes the
+                // offset discretely (per wheel notch / PageUp), so this is one repaint
+                // per scroll action, not per frame.
+                int reflowSig = HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, (int)scrollMode, feed.ScrollOffset);
                 if (reflowSig != lastReflowSig)
                 {
                     lastReflowSig = reflowSig;

--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -421,6 +421,9 @@ namespace Andy.Cli.Widgets
         /// <summary>Total wrapped line count from the last <see cref="Render"/> (content reflow signal).</summary>
         public int RenderedLineCount => _totalLinesCache;
 
+        /// <summary>Current scroll offset in lines from the bottom (0 = following the tail).</summary>
+        public int ScrollOffset => _scrollOffset;
+
         private int _totalLinesCache;
         private int _lastViewportHeight;
 

--- a/tests/Andy.Cli.Tests/Widgets/FeedViewReflowSignalTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/FeedViewReflowSignalTests.cs
@@ -119,16 +119,39 @@ public class FeedViewReflowSignalTests
     [Fact]
     public void ReflowSignature_ChangesWhenContentChanges()
     {
-        // Mirrors the signature Program.cs builds: HashCode.Combine(ItemCount, RenderedLineCount, scrollMode).
+        // Mirrors the signature Program.cs builds:
+        // HashCode.Combine(ItemCount, RenderedLineCount, scrollMode, ScrollOffset).
         // A different signature is what triggers the full clear+repaint that wipes margin residue.
         var feed = new FeedView();
         Render(feed);
-        int empty = System.HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, 0);
+        int empty = Signature(feed);
 
         feed.AddMarkdown("now there is content");
         Render(feed);
-        int withContent = System.HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, 0);
+        int withContent = Signature(feed);
 
         Assert.NotEqual(empty, withContent);
     }
+
+    [Fact]
+    public void ReflowSignature_ChangesWhenScrolled()
+    {
+        // Scrolling must change the reflow signature so the next frame is a full
+        // clear+repaint. Otherwise the diff renderer leaves stale glyphs (a lone
+        // "." or "n") behind in the unmanaged left margin / gap columns after a
+        // scroll. Regression guard for that fix.
+        var feed = new FeedView();
+        feed.AddMarkdown(string.Join("\n", System.Linq.Enumerable.Range(0, 100).Select(i => $"line {i}")));
+        Render(feed, height: 10); // content taller than the viewport so we can scroll
+
+        int atBottom = Signature(feed);
+        feed.ScrollLines(20, 10); // scroll up
+        Render(feed, height: 10);
+        int scrolled = Signature(feed);
+
+        Assert.NotEqual(atBottom, scrolled);
+    }
+
+    private static int Signature(FeedView feed)
+        => System.HashCode.Combine(feed.ItemCount, feed.RenderedLineCount, 0, feed.ScrollOffset);
 }


### PR DESCRIPTION
## Problem
After scrolling the feed, stray single glyphs (a lone `.` or `n`) were left behind in the left margin / gap columns. Reported after the mouse-wheel/PageUp fix (#76) made scrolling actually work.

## Cause
The diff renderer only repaints cells it draws, so with transparent backgrounds the unmanaged margin columns keep prior content. The existing full clear+repaint trigger (a "reflow signature") deliberately **excluded the scroll offset**, on the wrong assumption that scrolling only touches the diff-managed feed area.

## Fix
- Add `FeedView.ScrollOffset` and include it in the reflow signature (`Program.cs`), so each scroll triggers the same `ESC[2J` full clear+repaint that content changes do.
- Manual scrolling changes the offset discretely (one step per wheel notch / PageUp), so this is one repaint per scroll action — no continuous flicker.
- Regression test `ReflowSignature_ChangesWhenScrolled`.

## Verification
35 input/feed tests pass; full build clean.

Note: the trigger is verified by test + reasoning about the established clear mechanism, not a live visual repro. If residue persists, the fallback is to explicitly paint margin columns 0–2 opaque each frame.