### PR TITLE
Phase 3: enforce tool permissions in andy-cli with interactive consent

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -30,7 +30,8 @@
     <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
-    <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />
+    <PackageReference Include="Andy.Permissions" Version="2026.6.4-rc.4" />
+    <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.22" />
     <PackageReference Include="Andy.Tui" Version="2026.5.29-rc.43" />
     <PackageReference Include="JsonRepairSharp" Version="1.2.3" />
     <PackageReference Include="JsonSchema.Net" Version="9.2.0" />

--- a/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
+++ b/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
@@ -350,6 +350,9 @@ public static class HeadlessAgentRunner
         services.AddSingleton<IToolExecutor, ToolExecutor>();
         services.AddSingleton<IPermissionProfileService, Andy.Tools.Core.PermissionProfileService>();
         services.AddSingleton<Andy.Tools.Framework.IToolLifecycleManager, Andy.Tools.Framework.ToolLifecycleManager>();
+        // Gate tool execution through the permission engine. Headless is non-interactive: anything that
+        // would prompt is denied (fail-closed) unless ANDY_PERMISSION_MODE=bypass or rules/injection allow it.
+        Andy.Cli.Services.CliPermissionServiceExtensions.AddAndyCliPermissions(services, null);
         services.AddSingleton(new Andy.Tools.Framework.ToolFrameworkOptions
         {
             RegisterBuiltInTools = false,

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -16,6 +16,7 @@ using Andy.Llm;
 using Andy.Llm.Extensions;
 using Andy.Model.Llm;
 using Andy.Model.Model;
+using Andy.Permissions.Model;
 using Andy.Tools;
 using Andy.Tools.Core;
 using Andy.Tools.Execution;
@@ -311,6 +312,10 @@ class Program
             // services.AddTransient<Andy.Cli.Parsing.Compiler.LlmResponseCompiler>();
             // services.AddTransient<Andy.Cli.Parsing.Rendering.AstRenderer>();
 
+            // Broker for handing tool-permission requests from the agent's background task to the
+            // main input-owning loop (which renders the modal). Same instance used by DI and the loop.
+            var permissionBroker = new Andy.Cli.Services.PermissionRequestBroker();
+
             // Configure Tool services - manually register to avoid HostedService requirement
             // Core services from AddAndyTools
             services.AddSingleton<Andy.Tools.Validation.IToolValidator, Andy.Tools.Validation.ToolValidator>();
@@ -322,6 +327,8 @@ class Program
             services.AddSingleton<IToolExecutor, ToolExecutor>();
             services.AddSingleton<Andy.Tools.Core.IPermissionProfileService, Andy.Tools.Core.PermissionProfileService>();
             services.AddSingleton<Andy.Tools.Framework.IToolLifecycleManager, Andy.Tools.Framework.ToolLifecycleManager>();
+            // Gate tool execution through the permission engine (interactive prompt for the TUI).
+            services.AddAndyCliPermissions(permissionBroker);
 
             // Framework options
             services.AddSingleton(new Andy.Tools.Framework.ToolFrameworkOptions
@@ -807,6 +814,74 @@ class Program
                 return confirmExit;
             }
 
+            // Modal asking the user to approve/deny a tool call. Runs on the main thread (which owns the
+            // input queue and renderer), reusing the same render + blocking-keypress primitive as the exit
+            // dialog. Returns the decision to hand back to the awaiting agent task.
+            async Task<PermissionDecision> ShowPermissionDialogAsync(PermissionRequest request)
+            {
+                string[] labels = { "Allow once", "Allow (session)", "Deny" };
+                int selected = 2; // default to the safe choice
+                bool open = true;
+
+                string Trunc(string s, int max) => s.Length <= max ? s : s[..Math.Max(0, max - 1)] + "…";
+
+                while (open)
+                {
+                    var pb = new DL.DisplayListBuilder();
+                    pb.PushClip(new DL.ClipPush(0, 0, viewport.Width, viewport.Height));
+                    pb.DrawRect(new DL.Rect(0, 0, viewport.Width, viewport.Height, new DL.Rgb24(0, 0, 0)));
+
+                    int bw = Math.Min(64, viewport.Width - 4);
+                    int bh = 9;
+                    int bx = (viewport.Width - bw) / 2;
+                    int by = (viewport.Height - bh) / 2;
+
+                    pb.PushClip(new DL.ClipPush(bx, by, bw, bh));
+                    pb.DrawRect(new DL.Rect(bx, by, bw, bh, new DL.Rgb24(30, 30, 40)));
+                    pb.DrawBorder(new DL.Border(bx, by, bw, bh, "double", new DL.Rgb24(200, 200, 80)));
+
+                    string title = "Permission required";
+                    pb.DrawText(new DL.TextRun(bx + (bw - title.Length) / 2, by + 1, title, new DL.Rgb24(255, 255, 255), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.Bold));
+
+                    var tool = Trunc($"Tool: {request.ToolDisplayName ?? request.ToolId}", bw - 4);
+                    pb.DrawText(new DL.TextRun(bx + 2, by + 3, tool, new DL.Rgb24(220, 220, 160), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.None));
+                    var summary = Trunc(request.ActionSummary, bw - 4);
+                    pb.DrawText(new DL.TextRun(bx + 2, by + 4, summary, new DL.Rgb24(200, 200, 210), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.None));
+
+                    int btnY = by + 6;
+                    int x = bx + 2;
+                    for (int i = 0; i < labels.Length; i++)
+                    {
+                        bool on = i == selected;
+                        var bg = on ? new DL.Rgb24(60, 90, 130) : new DL.Rgb24(40, 40, 50);
+                        var fg = on ? new DL.Rgb24(255, 255, 255) : new DL.Rgb24(180, 180, 180);
+                        string text = on ? $"[ {labels[i]} ]" : $"  {labels[i]}  ";
+                        pb.DrawRect(new DL.Rect(x, btnY, text.Length, 1, bg));
+                        pb.DrawText(new DL.TextRun(x, btnY, text, fg, bg, on ? DL.CellAttrFlags.Bold : DL.CellAttrFlags.None));
+                        x += text.Length + 2;
+                    }
+
+                    string hints = "← → Navigate  Enter Select  Esc Deny";
+                    pb.DrawText(new DL.TextRun(bx + (bw - hints.Length) / 2, by + bh - 1, hints, new DL.Rgb24(120, 120, 150), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.None));
+
+                    pb.Pop();
+                    await scheduler.RenderOnceAsync(pb.Build(), viewport, caps, pty, CancellationToken.None);
+
+                    var k = ReadKeyBlocking();
+                    if (k.Key == ConsoleKey.LeftArrow) selected = (selected + labels.Length - 1) % labels.Length;
+                    else if (k.Key == ConsoleKey.RightArrow || k.Key == ConsoleKey.Tab) selected = (selected + 1) % labels.Length;
+                    else if (k.Key == ConsoleKey.Escape || k.Key == ConsoleKey.D || k.Key == ConsoleKey.N) { selected = 2; open = false; }
+                    else if (k.Key == ConsoleKey.Enter || k.Key == ConsoleKey.Spacebar) open = false;
+                }
+
+                return selected switch
+                {
+                    0 => new PermissionDecision(true, PersistScope.Once),
+                    1 => new PermissionDecision(true, PersistScope.Session),
+                    _ => new PermissionDecision(false, PersistScope.Once),
+                };
+            }
+
             while (running)
             {
                 // Check for terminal resize
@@ -819,6 +894,16 @@ class Program
                     // Force a full redraw on resize
                     Console.Clear();
                 }
+
+                // Service a pending tool-permission request (posted by the agent's background task) on
+                // this input-owning thread, then re-render on the next iteration.
+                if (permissionBroker.TryDequeue(out var pendingPermission) && pendingPermission != null)
+                {
+                    var decision = await ShowPermissionDialogAsync(pendingPermission.Request);
+                    pendingPermission.Completion.TrySetResult(decision);
+                    continue;
+                }
+
                 // Input (prefer KeyAvailable; fallback to Console.In.Peek in non-interactive contexts)
                 async Task HandleKey(ConsoleKeyInfo k)
                 {
@@ -1691,6 +1776,8 @@ class Program
         services.AddSingleton<IToolExecutor, ToolExecutor>();
         services.AddSingleton<Andy.Tools.Core.IPermissionProfileService, Andy.Tools.Core.PermissionProfileService>();
         services.AddSingleton<Andy.Tools.Framework.IToolLifecycleManager, Andy.Tools.Framework.ToolLifecycleManager>();
+        // Gate tool execution through the permission engine (non-interactive: fail-closed / bypass via env).
+        services.AddAndyCliPermissions(null);
 
         // Framework options
         services.AddSingleton(new Andy.Tools.Framework.ToolFrameworkOptions
@@ -1818,6 +1905,8 @@ class Program
         services.AddSingleton<IToolExecutor, ToolExecutor>();
         services.AddSingleton<Andy.Tools.Core.IPermissionProfileService, Andy.Tools.Core.PermissionProfileService>();
         services.AddSingleton<Andy.Tools.Framework.IToolLifecycleManager, Andy.Tools.Framework.ToolLifecycleManager>();
+        // Gate tool execution through the permission engine (non-interactive: fail-closed / bypass via env).
+        services.AddAndyCliPermissions(null);
 
         // Framework options
         services.AddSingleton(new Andy.Tools.Framework.ToolFrameworkOptions

--- a/src/Andy.Cli/Services/CliPermissionPrompt.cs
+++ b/src/Andy.Cli/Services/CliPermissionPrompt.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using Andy.Permissions.DependencyInjection;
+using Andy.Permissions.Model;
+using Andy.Permissions.Prompt;
+using Andy.Permissions.Store;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Andy.Cli.Services;
+
+/// <summary>
+/// A single pending tool-permission request awaiting a decision from the UI thread. The agent runs on a
+/// background task; it posts one of these to the <see cref="PermissionRequestBroker"/> and awaits
+/// <see cref="Completion"/>, which the main render/input loop completes after showing a modal.
+/// </summary>
+public sealed class PendingPermissionRequest
+{
+    public required PermissionRequest Request { get; init; }
+
+    public TaskCompletionSource<PermissionDecision> Completion { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+/// <summary>
+/// Thread-safe hand-off between the agent's background tool-execution task and the main TUI loop, which
+/// owns the terminal input/render. The permission engine already serializes prompts, so at most one
+/// request is pending at a time.
+/// </summary>
+public sealed class PermissionRequestBroker
+{
+    private readonly ConcurrentQueue<PendingPermissionRequest> _queue = new();
+
+    public bool HasPending => !_queue.IsEmpty;
+
+    public void Enqueue(PendingPermissionRequest request) => _queue.Enqueue(request);
+
+    public bool TryDequeue(out PendingPermissionRequest? request) => _queue.TryDequeue(out request);
+}
+
+/// <summary>
+/// Interactive <see cref="IPermissionPrompt"/> for the TUI: posts the request to the broker and awaits the
+/// main loop's decision. Cancellation resolves to a deny.
+/// </summary>
+public sealed class CliPermissionPrompt : IPermissionPrompt
+{
+    private readonly PermissionRequestBroker _broker;
+
+    public CliPermissionPrompt(PermissionRequestBroker broker) => _broker = broker;
+
+    public Task<PermissionDecision> RequestAsync(PermissionRequest request, CancellationToken cancellationToken = default)
+    {
+        var pending = new PendingPermissionRequest { Request = request };
+        cancellationToken.Register(() => pending.Completion.TrySetResult(PermissionDecision.DenyOnce));
+        _broker.Enqueue(pending);
+        return pending.Completion.Task;
+    }
+}
+
+/// <summary>DI helpers for wiring the permission system into andy-cli's service collections.</summary>
+public static class CliPermissionServiceExtensions
+{
+    /// <summary>
+    /// Wires the permission engine (authorizer + layered store + decorating executor) into the service
+    /// collection. Call after <c>IToolExecutor</c> is registered. When <paramref name="interactiveBroker"/>
+    /// is provided, the TUI's interactive prompt is used; otherwise the default non-interactive prompt
+    /// (fail-closed, or bypass via <c>ANDY_PERMISSION_MODE</c>) handles Ask in headless/ACP contexts.
+    /// </summary>
+    public static IServiceCollection AddAndyCliPermissions(this IServiceCollection services, PermissionRequestBroker? interactiveBroker)
+    {
+        if (interactiveBroker is not null)
+        {
+            services.AddSingleton(interactiveBroker);
+            services.AddSingleton<IPermissionPrompt>(new CliPermissionPrompt(interactiveBroker));
+        }
+
+        services.AddAndyPermissions(options =>
+        {
+            options.WithProjectDirectory(Directory.GetCurrentDirectory());
+            // Safe-by-default: mutating file tools prompt unless a higher layer allows them (reads stay
+            // auto-allowed; execute_command already asks via its capability). User/project/injected rules
+            // and "Allow (session)" override these.
+            options.Builtin = AppendAskDefaults(options.Builtin);
+        });
+        return services;
+    }
+
+    private static IReadOnlyList<PermissionRule> AppendAskDefaults(IReadOnlyList<PermissionRule> builtin)
+    {
+        string[] mutating = { "write_file", "delete_file", "move_file", "copy_file", "file_editor", "replace_text", "create_directory" };
+        var list = new List<PermissionRule>(builtin);
+        foreach (var tool in mutating)
+        {
+            list.Add(PermissionRule.Parse($"{tool}(*)", PermissionOutcome.Ask, PermissionLayer.Builtin));
+        }
+
+        return list;
+    }
+}

--- a/src/Andy.Cli/Services/ToolCatalog.cs
+++ b/src/Andy.Cli/Services/ToolCatalog.cs
@@ -39,6 +39,7 @@ public static class ToolCatalog
         // System tools
         RegisterTool<ProcessInfoTool>(services);
         RegisterTool<SystemInfoTool>(services);
+        RegisterTool<ExecuteCommandTool>(services);
 
         // Text processing tools
         RegisterTool<FormatTextTool>(services);
@@ -58,7 +59,8 @@ public static class ToolCatalog
 
         // Custom CLI tools
         RegisterTool<Andy.Cli.Tools.CreateDirectoryTool>(services);
-        RegisterTool<Andy.Cli.Tools.BashCommandTool>(services);
+        // BashCommandTool retired: it was display-only (never executed). Real shell execution is now
+        // provided by Andy.Tools' ExecuteCommandTool (id "execute_command"), gated by the permission layer.
         RegisterTool<Andy.Cli.Tools.CodeIndexTool>(services);
     }
 

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
-    <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />
+    <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.22" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="JsonSchema.Net" Version="9.2.0" />
@@ -61,6 +61,7 @@
     <Compile Include="Tools/CodeIndexToolTests.cs" />
     <!-- Parallel tool execution tests -->
     <Compile Include="Services/ParallelToolExecutionTests.cs" />
+    <Compile Include="Services/CliPermissionPromptTests.cs" />
     <!-- ACP integration tests -->
     <Compile Include="ACP/AndyAgentProviderTests.cs" />
     <!-- Multi-turn conversation context tests -->

--- a/tests/Andy.Cli.Tests/Services/CliPermissionPromptTests.cs
+++ b/tests/Andy.Cli.Tests/Services/CliPermissionPromptTests.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Cli.Services;
+using Andy.Permissions.Model;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services;
+
+public class CliPermissionPromptTests
+{
+    private static PermissionRequest Req() =>
+        new("execute_command", "Execute Command", "run ls",
+            new PermissionEvaluation(PermissionOutcome.Ask, System.Array.Empty<EvaluatedResource>()));
+
+    [Fact]
+    public async Task RequestAsync_posts_to_broker_and_completes_with_decision()
+    {
+        var broker = new PermissionRequestBroker();
+        var prompt = new CliPermissionPrompt(broker);
+
+        var task = prompt.RequestAsync(Req(), CancellationToken.None);
+
+        Assert.True(broker.TryDequeue(out var pending));
+        Assert.NotNull(pending);
+        Assert.False(task.IsCompleted); // still awaiting the UI decision
+
+        pending!.Completion.TrySetResult(new PermissionDecision(true, PersistScope.Session));
+
+        var decision = await task;
+        Assert.True(decision.Allowed);
+        Assert.Equal(PersistScope.Session, decision.Persist);
+        Assert.False(broker.HasPending);
+    }
+
+    [Fact]
+    public async Task Cancellation_resolves_to_deny()
+    {
+        var broker = new PermissionRequestBroker();
+        var prompt = new CliPermissionPrompt(broker);
+        using var cts = new CancellationTokenSource();
+
+        var task = prompt.RequestAsync(Req(), cts.Token);
+        cts.Cancel();
+
+        var decision = await task;
+        Assert.False(decision.Allowed);
+    }
+}


### PR DESCRIPTION
Part of the tool-permission rollout (epic rivoli-ai/andy-engine#5, issue rivoli-ai/andy-engine#8).
Integrates the `Andy.Permissions` engine so tool calls are actually gated in andy-cli.

## Changes
- **Packages**: `Andy.Tools` 2025.10.16-rc.16 → **2026.6.4-rc.22** (adds the real `execute_command`); new **`Andy.Permissions` 2026.6.4-rc.4**.
- **Retire display-only `bash_command`**: removed from `ToolCatalog`; registered the real `execute_command` (gated by the permission layer).
- **Enforcement wired into all DI paths** (TUI, ACP, CLI-args, headless) via `AddAndyCliPermissions` — decorates `IToolExecutor` with `PermissionedToolExecutor`. Rules discovered from `<cwd>/.andy/permissions.json` (+`.local.json`) and `~/.andy/permissions.json`; managed + injected layers supported.
- **Interactive consent (TUI)**: `PermissionRequestBroker` hands a request from the agent's background task to the main input-owning loop, which renders a 3-choice modal (**Allow once / Allow session / Deny**) reusing the proven exit-dialog render + blocking-keypress primitive. The engine serializes prompts, so at most one is pending.
- **Headless/ACP**: non-interactive — fail-closed by default, `ANDY_PERMISSION_MODE=bypass` for trusted sandboxes; inject rules via `ANDY_PERMISSIONS_FILE`/`_JSON`.
- **Safe-by-default policy**: mutating file tools (`write/delete/move/copy/edit/replace/create_directory`) prompt; reads auto-allow; `execute_command` asks via its ProcessExecution capability. Known read-only shell commands auto-allow; dangerous ones (`rm -rf`, `sudo`, …) and redirection force Ask.

## Tests
`CliPermissionPromptTests` (broker hand-off completes on decision; cancellation → deny). Full suite **342 passing**, 1 pre-existing skip. Builds clean.

## ⚠️ Needs human verification before merge
The interactive TUI modal cannot be exercised by automated tests (it needs a real terminal). Please verify:
1. Run `andy` in a repo with no `.andy/permissions.json`; ask it to run a shell command (e.g. "run npm test") → the **Allow once / Allow session / Deny** modal should appear; arrows + Enter select; Esc denies.
2. "Allow session" should suppress re-prompts for that command for the rest of the run.
3. Ask it to write a file → should prompt; reads should not.
4. Headless (`--headless`) should not prompt (fail-closed) unless `ANDY_PERMISSION_MODE=bypass` or rules allow.

Holding merge for your review since I can't drive the TUI.