### PR TITLE
Phase 5: use the built-in ToolExecutor permission gate (bump Andy.Tools rc.24 + Andy.Permissions rc.6)

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -30,8 +30,8 @@
     <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
-    <PackageReference Include="Andy.Permissions" Version="2026.6.4-rc.4" />
-    <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.22" />
+    <PackageReference Include="Andy.Permissions" Version="2026.6.4-rc.6" />
+    <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.24" />
     <PackageReference Include="Andy.Tui" Version="2026.5.29-rc.43" />
     <PackageReference Include="JsonRepairSharp" Version="1.2.3" />
     <PackageReference Include="JsonSchema.Net" Version="9.2.0" />

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
-    <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.22" />
+    <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.24" />
     <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="JsonSchema.Net" Version="9.2.0" />


### PR DESCRIPTION
Final step of the permission rollout (rivoli-ai/andy-engine#10). Bumps to the versions where the permission consent is built into Andy.Tools' `ToolExecutor` (via `IToolPermissionGate`) rather than an external decorator.

- **Andy.Tools** 2026.6.4-rc.22 → **rc.24** (adds `IToolPermissionGate`, consulted by `ToolExecutor`).
- **Andy.Permissions** rc.4 → **rc.6** (`AddAndyPermissions` now registers the gate instead of decorating).
- **No CLI code change** beyond version bumps: `AddAndyCliPermissions` already calls `AddAndyPermissions`; the interactive consent path is unchanged (the gate prompts via `CliPermissionPrompt` + `PermissionRequestBroker` on the main loop).

Build clean; **342 tests pass** (1 pre-existing skip). Same manual-verification points as #78 apply (the TUI modal can't be automated).