### PR TITLE
Fix: bash tool (execute_command) blocked in the live CLI by the capability check before the gate

### DIFF
--- a/src/Andy.Cli/Services/UiUpdatingToolExecutor.cs
+++ b/src/Andy.Cli/Services/UiUpdatingToolExecutor.cs
@@ -49,6 +49,13 @@ namespace Andy.Cli.Services
             // Ensure we have a context with a correlation ID
             context ??= new ToolExecutionContext();
 
+            // The Andy.Permissions gate is the CLI's consent authority (allow/ask/deny per call). Grant the
+            // capability flags on the profile so the lower-level capability checks
+            // (SecurityManager.ValidateExecution + ToolBase.CanExecuteWithPermissions) don't pre-empt the
+            // gate. Without this, tools that declare ProcessExecution (execute_command) are blocked before
+            // the gate runs, because the engine builds the context with the restrictive default profile.
+            GrantGatedCapabilities(context);
+
             // If no correlation ID is set, create a unique one for this execution
             if (string.IsNullOrEmpty(context.CorrelationId))
             {
@@ -489,7 +496,25 @@ namespace Andy.Cli.Services
 
         public Task<ToolExecutionResult> ExecuteAsync(ToolExecutionRequest request)
         {
+            if (request?.Context != null)
+            {
+                GrantGatedCapabilities(request.Context);
+            }
+
             return _innerExecutor.ExecuteAsync(request);
+        }
+
+        /// <summary>
+        /// Grants the tool capability flags on the execution context's permission profile. The
+        /// Andy.Permissions gate decides actual consent per call; these flags only stop the lower-level
+        /// capability checks from blocking a tool before the gate runs.
+        /// </summary>
+        private static void GrantGatedCapabilities(ToolExecutionContext context)
+        {
+            context.Permissions.FileSystemAccess = true;
+            context.Permissions.NetworkAccess = true;
+            context.Permissions.ProcessExecution = true;
+            context.Permissions.EnvironmentAccess = true;
         }
 
         public Task<IList<string>> ValidateExecutionRequestAsync(ToolExecutionRequest request)

--- a/tests/Andy.Cli.Tests/Integration/ExecuteCommandToolIntegrationTests.cs
+++ b/tests/Andy.Cli.Tests/Integration/ExecuteCommandToolIntegrationTests.cs
@@ -104,6 +104,25 @@ public sealed class ExecuteCommandToolIntegrationTests
     }
 
     [Fact]
+    public async Task Execute_command_runs_with_engine_default_profile_via_ui_executor()
+    {
+        // Reproduces the live path: the engine's SimpleAgent builds the context with the restrictive
+        // DEFAULT permission profile (ProcessExecution = false) and the call goes through
+        // UiUpdatingToolExecutor. execute_command declares the ProcessExecution capability, so without the
+        // capability grant in UiUpdatingToolExecutor it would be blocked before the permission gate runs.
+        using var sp = BuildProvider();
+        var inner = sp.GetRequiredService<IToolExecutor>();
+        var exec = new UiUpdatingToolExecutor(inner);
+
+        var defaultContext = new ToolExecutionContext(); // ProcessExecution defaults to false, like SimpleAgent
+        var result = await exec.ExecuteAsync("execute_command", Cmd("echo via_ui_executor"), defaultContext);
+
+        var (ok, _, stdout, err) = Read(result);
+        Assert.True(ok, err);
+        Assert.Contains("via_ui_executor", stdout);
+    }
+
+    [Fact]
     public async Task Known_safe_command_pwd_or_cd_runs()
     {
         using var sp = BuildProvider();


### PR DESCRIPTION
## Bug
In the live CLI the bash tool never ran. The engine's `SimpleAgent` builds the tool `ToolExecutionContext` with the **restrictive default permission profile** (`ProcessExecution = false`). `execute_command` declares the `ProcessExecution` capability, so `SecurityManager.ValidateExecution` (and `ToolBase.CanExecuteWithPermissions`) rejected it with *"Tool requires process execution but it is not granted"* — **before** the Andy.Permissions consent gate ever ran. (`list_directory` was fine: it only needs `FileSystemRead`, which the default profile grants — that's why the earlier 'list directory' report was actually a stale excluded test, not this.)

## Fix
`UiUpdatingToolExecutor` wraps every agent tool call; it now grants the capability flags (FileSystem / Network / ProcessExecution / Environment) on the context. The **permission gate stays the real authority** (allow / ask / deny per call) — these flags only stop the lower-level capability checks from pre-empting it.

## Test
Added `Execute_command_runs_with_engine_default_profile_via_ui_executor`, which runs `execute_command` through `UiUpdatingToolExecutor` with the engine's default profile. Verified it **fails without the fix** (`Tool requires process execution but it is not granted`) and passes with it. Full suite **351 green**.