### PR TITLE
Fix: command output uses full feed width instead of 80-char cap

### DIFF
--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -1664,6 +1664,9 @@ namespace Andy.Cli.Widgets
         private int _linesRemoved;
         private string _filePath = "";
         private readonly List<string> _details = new();
+        // Width available for rendering the current slice, captured in RenderSlice so
+        // result-summary helpers can fill the full feed width instead of a narrow cap.
+        private int _availableWidth = 80;
 
         public string ToolId => _toolId;
         public string ToolName => _toolName;
@@ -1941,6 +1944,10 @@ namespace Andy.Cli.Widgets
         public void RenderSlice(int x, int y, int width, int startLine, int maxLines, DL.DisplayList baseDl, DL.DisplayListBuilder b)
         {
             if (width <= 0 || maxLines <= 0) return;
+
+            // Remember the full available width so single-line summaries (e.g. command
+            // output) can use the entire feed width instead of a narrow hard-coded cap.
+            _availableWidth = width;
 
             int row = y;
             int drawn = 0;
@@ -2340,12 +2347,17 @@ namespace Andy.Cli.Widgets
             return s.Replace("\n", " ").Replace("\r", " ").Trim();
         }
 
-        private static string FirstLine(string s)
+        private string FirstLine(string s)
         {
             var line = s.Replace("\r\n", "\n").Replace('\r', '\n');
             var nl = line.IndexOf('\n');
             if (nl >= 0) line = line.Substring(0, nl);
-            if (line.Length > 80) line = line.Substring(0, 77) + "...";
+            // Fill the available feed width rather than a narrow hard-coded cap so wide
+            // command output is not needlessly clipped to ~1/3 of the terminal. The final
+            // render also clips to the exact width; this keeps the content budget aligned
+            // with the available space. Reserve a few columns for the "  L  " gutter/prefix.
+            int budget = Math.Max(40, _availableWidth - 6);
+            if (line.Length > budget) line = line.Substring(0, Math.Max(0, budget - 3)) + "...";
             return line.Trim();
         }
 

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -55,6 +55,8 @@
     <Compile Include="Widgets/FeedViewReflowSignalTests.cs" />
     <!-- FeedView scroll-offset clamp tests (PageUp/PageDown/wheel dead-zone fix) -->
     <Compile Include="Widgets/FeedViewScrollClampTests.cs" />
+    <!-- Command output width tests (full-width command output, no narrow cap) -->
+    <Compile Include="Widgets/CommandOutputWidthTests.cs" />
     <!-- Raw terminal input decoder tests (mouse wheel + keyboard) -->
     <Compile Include="Input/TerminalInputParserTests.cs" />
     <!-- Code indexing tests -->

--- a/tests/Andy.Cli.Tests/Widgets/CommandOutputWidthTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/CommandOutputWidthTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Andy.Cli.Widgets;
+using Xunit;
+using DL = Andy.Tui.DisplayList;
+using L = Andy.Tui.Layout;
+
+namespace Andy.Cli.Tests.Widgets
+{
+    /// <summary>
+    /// Regression tests for command-output width: when a command (execute_command)
+    /// runs, its single-line result/summary shown in the feed must use the full
+    /// available feed width instead of being clipped to a narrow hard-coded cap
+    /// (~80 chars, which is roughly 1/3 of a wide terminal).
+    /// </summary>
+    public class CommandOutputWidthTests : ToolRenderingTestBase
+    {
+        private static void SetAvailableWidth(RunningToolItem item, int width)
+        {
+            var field = typeof(RunningToolItem).GetField(
+                "_availableWidth",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            field!.SetValue(item, width);
+        }
+
+        private static string Render(RunningToolItem item, int width)
+        {
+            // Render the item into a fresh DisplayList at the given width. This sets
+            // the internal available-width used by the summary helpers, mirroring how
+            // FeedView renders feed items.
+            var baseDl = new DL.DisplayListBuilder().Build();
+            var b = new DL.DisplayListBuilder();
+            item.RenderSlice(0, 0, width, 0, 10, baseDl, b);
+            b.Build();
+            return GetResultSummary(item);
+        }
+
+        [Fact]
+        public void CommandError_Summary_UsesFullWidth_NotNarrowCap()
+        {
+            // A long single-line command error. Old behavior capped the summary at 80
+            // chars regardless of terminal width.
+            var longOutput = new string('x', 400);
+            var parameters = new Dictionary<string, object?> { { "command", "ls -la" } };
+
+            var item = CreateToolItem("execute_command", parameters);
+            item.SetComplete(false, "0.5s");
+            item.SetResult(longOutput);
+
+            // Render at a wide width (240 columns).
+            var wide = Render(item, 240);
+            // Render at a narrow width (80 columns).
+            var narrowItem = CreateToolItem("execute_command", parameters);
+            narrowItem.SetComplete(false, "0.5s");
+            narrowItem.SetResult(longOutput);
+            var narrow = Render(narrowItem, 80);
+
+            // The wide render must produce a noticeably longer summary than the narrow
+            // one: the content now scales with available width instead of a 80-char cap.
+            Assert.True(wide.Length > narrow.Length,
+                $"Expected wide summary ({wide.Length}) to be longer than narrow ({narrow.Length})");
+
+            // And the wide summary should clearly exceed the old ~80-char limit.
+            Assert.True(wide.Length > 120,
+                $"Expected wide command summary to exceed the old narrow cap, got {wide.Length} chars");
+        }
+
+        [Fact]
+        public void CommandError_Summary_DefaultWidth_RemainsBounded()
+        {
+            // Without rendering, the default available width (80) keeps summaries bounded
+            // so non-rendering callers (e.g. plain summary inspection) stay reasonable.
+            var longOutput = new string('y', 400);
+            var parameters = new Dictionary<string, object?> { { "command", "echo hi" } };
+
+            var item = CreateToolItem("execute_command", parameters);
+            item.SetComplete(false, "0.5s");
+            item.SetResult(longOutput);
+
+            var summary = GetResultSummary(item);
+            Assert.True(summary.Length <= 80,
+                $"Expected default summary to stay within the 80-char default, got {summary.Length}");
+        }
+
+        [Fact]
+        public void CommandTool_RenderSlice_WideWidth_DoesNotThrow()
+        {
+            var parameters = new Dictionary<string, object?> { { "command", "find / -name '*.cs'" } };
+            var item = CreateToolItem("execute_command", parameters);
+            item.SetComplete(true, "1.0s");
+            item.SetResult(new string('z', 500));
+
+            var baseDl = new DL.DisplayListBuilder().Build();
+            var b = new DL.DisplayListBuilder();
+
+            // Should render cleanly across a range of widths, including very wide ones.
+            item.RenderSlice(0, 0, 240, 0, 10, baseDl, b);
+            item.RenderSlice(0, 0, 40, 0, 10, baseDl, b);
+            b.Build();
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Command (`execute_command`) output in the feed was clipped to ~1/3 of a wide terminal. Root cause: a hard-coded `if (line.Length > 80) Substring(0, 77) + "..."` cap in `RunningToolItem.FirstLine`; on a 240-column terminal that 80-char cap is about one third of the width.

## Change
- Captures the real feed width in `RunningToolItem` during `RenderSlice` and makes `FirstLine` budget against it (full width minus a small gutter, min 40) instead of the fixed 80.
- Keeps the 80 default for non-rendering callers. No scroll/auto-scroll logic touched.

## Tests
3 new tests in `CommandOutputWidthTests.cs` (wide vs narrow summary length, default-width bound, wide render no-throw). Full suite green.

## Caveats
- Widens the single-line summary line; does not introduce multi-line wrapping of full output (that would be a larger render-model change).
