### PR TITLE
Fix: stop re-prompting for similar commands after session Allow

### DIFF
--- a/src/Andy.Cli/Services/CliPermissionPrompt.cs
+++ b/src/Andy.Cli/Services/CliPermissionPrompt.cs
@@ -39,19 +39,152 @@ public sealed class PermissionRequestBroker
 /// <summary>
 /// Interactive <see cref="IPermissionPrompt"/> for the TUI: posts the request to the broker and awaits the
 /// main loop's decision. Cancellation resolves to a deny.
+///
+/// When the user picks "Allow (session)", the permission engine on its own remembers a rule whose command
+/// specifier is the *full* command line (e.g. <c>execute_command(gh pr list --limit 10:*)</c>). Because
+/// command matching is a word-boundary prefix match, a near-identical follow-up such as
+/// <c>gh pr list --limit 20</c> does not match and the user is prompted again. To stop that re-prompting,
+/// after a session Allow this prompt also installs a broader session rule keyed to the *command class*
+/// rather than the exact arguments (see <see cref="GrantBroadenedSessionRules"/>).
 /// </summary>
 public sealed class CliPermissionPrompt : IPermissionPrompt
 {
     private readonly PermissionRequestBroker _broker;
+    private readonly IPermissionStore? _store;
 
-    public CliPermissionPrompt(PermissionRequestBroker broker) => _broker = broker;
+    public CliPermissionPrompt(PermissionRequestBroker broker, IPermissionStore? store = null)
+    {
+        _broker = broker;
+        _store = store;
+    }
 
     public Task<PermissionDecision> RequestAsync(PermissionRequest request, CancellationToken cancellationToken = default)
     {
         var pending = new PendingPermissionRequest { Request = request };
         cancellationToken.Register(() => pending.Completion.TrySetResult(PermissionDecision.DenyOnce));
         _broker.Enqueue(pending);
-        return pending.Completion.Task;
+
+        // After the UI resolves the decision, broaden a session Allow so similar commands are not re-prompted.
+        return pending.Completion.Task.ContinueWith(t =>
+        {
+            var decision = t.Result;
+            if (decision.Allowed && decision.Persist == PersistScope.Session)
+            {
+                GrantBroadenedSessionRules(request, _store);
+            }
+
+            return decision;
+        }, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+    }
+
+    /// <summary>
+    /// Grant granularity for a session "Allow": tool id + command class, where the command class is the
+    /// executable leaf name plus its first subcommand token (e.g. <c>gh pr</c>, <c>git status</c>,
+    /// <c>npm run</c>; a command with no subcommand stays at the executable, e.g. <c>ls</c>). The rule is
+    /// session-scoped only (in-memory, lost on exit) and applies only to the same tool.
+    ///
+    /// Rationale: matching on the executable + first subcommand stops re-prompting for argument-only
+    /// variations of the *same* action a user already approved, while staying narrow enough that approving
+    /// <c>gh pr list</c> does NOT silently authorize an unrelated <c>gh repo delete</c> or a different
+    /// executable such as <c>rm -rf</c>. Each command segment the engine flagged for Ask is broadened
+    /// independently, so a compound command only broadens the parts that actually required consent.
+    /// </summary>
+    internal static void GrantBroadenedSessionRules(PermissionRequest request, IPermissionStore? store)
+    {
+        if (store is null)
+        {
+            return;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var resource in request.Evaluation.Resources)
+        {
+            if (resource.Outcome != PermissionOutcome.Ask || resource.Access.Kind != ResourceKind.Command)
+            {
+                continue;
+            }
+
+            var commandClass = CommandClass(resource.Access.Value);
+            if (string.IsNullOrEmpty(commandClass) || !seen.Add(commandClass))
+            {
+                continue;
+            }
+
+            var rule = PermissionRule.Parse(
+                $"{request.ToolId}({commandClass}:*)", PermissionOutcome.Allow, PermissionLayer.Session);
+            store.AddSessionRule(rule);
+        }
+    }
+
+    /// <summary>
+    /// Reduces a command string to its command class: the executable leaf name plus the first
+    /// subcommand-like token. Leading <c>VAR=value</c> assignments are skipped; the first token that looks
+    /// like a flag/option (starts with <c>-</c>) or is not a bare word terminates the class. Returns an empty
+    /// string when no usable executable token is found.
+    /// </summary>
+    internal static string CommandClass(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return string.Empty;
+        }
+
+        var tokens = command.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        int i = 0;
+
+        // Skip leading environment assignments (FOO=bar) that precede the executable.
+        while (i < tokens.Length && IsAssignment(tokens[i]))
+        {
+            i++;
+        }
+
+        if (i >= tokens.Length || !IsBareWord(tokens[i]) || tokens[i].StartsWith("-", StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        var exe = LeafName(tokens[i]);
+        i++;
+
+        // Append the first subcommand token if it is a bare word (not a flag/option/path/redirection).
+        if (i < tokens.Length && IsBareWord(tokens[i]) && !tokens[i].StartsWith("-", StringComparison.Ordinal))
+        {
+            return $"{exe} {tokens[i]}";
+        }
+
+        return exe;
+    }
+
+    private static bool IsAssignment(string token)
+    {
+        int eq = token.IndexOf('=');
+        return eq > 0 && IsBareWord(token[..eq]);
+    }
+
+    private static bool IsBareWord(string token)
+    {
+        if (token.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var c in token)
+        {
+            // Reject shell metacharacters / quoting so we never widen on something we cannot reason about.
+            if (c == '|' || c == '&' || c == ';' || c == '<' || c == '>' || c == '`' ||
+                c == '$' || c == '(' || c == ')' || c == '"' || c == '\'')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string LeafName(string path)
+    {
+        int slash = path.LastIndexOfAny(new[] { '/', '\\' });
+        return slash >= 0 ? path[(slash + 1)..] : path;
     }
 }
 
@@ -64,12 +197,19 @@ public static class CliPermissionServiceExtensions
     /// is provided, the TUI's interactive prompt is used; otherwise the default non-interactive prompt
     /// (fail-closed, or bypass via <c>ANDY_PERMISSION_MODE</c>) handles Ask in headless/ACP contexts.
     /// </summary>
-    public static IServiceCollection AddAndyCliPermissions(this IServiceCollection services, PermissionRequestBroker? interactiveBroker)
+    public static IServiceCollection AddAndyCliPermissions(
+        this IServiceCollection services,
+        PermissionRequestBroker? interactiveBroker,
+        Action<PermissionStoreOptions>? configureStore = null)
     {
         if (interactiveBroker is not null)
         {
             services.AddSingleton(interactiveBroker);
-            services.AddSingleton<IPermissionPrompt>(new CliPermissionPrompt(interactiveBroker));
+            // Resolve the prompt lazily so it can capture the IPermissionStore that AddAndyPermissions
+            // registers below. The store lets a session "Allow" install a broadened command-class rule that
+            // prevents re-prompting for similar invocations.
+            services.AddSingleton<IPermissionPrompt>(sp =>
+                new CliPermissionPrompt(interactiveBroker, sp.GetService<IPermissionStore>()));
         }
 
         services.AddAndyPermissions(options =>
@@ -79,6 +219,8 @@ public static class CliPermissionServiceExtensions
             // auto-allowed; execute_command already asks via its capability). User/project/injected rules
             // and "Allow (session)" override these.
             options.Builtin = AppendAskDefaults(options.Builtin);
+            // Optional caller hook (used by tests to isolate file-backed layers for determinism).
+            configureStore?.Invoke(options);
         });
         return services;
     }

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -62,12 +62,14 @@
     <!-- Parallel tool execution tests -->
     <Compile Include="Services/ParallelToolExecutionTests.cs" />
     <Compile Include="Services/CliPermissionPromptTests.cs" />
+    <Compile Include="Services/CliPermissionSessionBroadeningTests.cs" />
     <!-- ACP integration tests -->
     <Compile Include="ACP/AndyAgentProviderTests.cs" />
     <!-- Multi-turn conversation context tests -->
     <Compile Include="Integration/MultiTurnToolCallContextTests.cs" />
     <!-- Bash tool (execute_command) integration tests -->
     <Compile Include="Integration/ExecuteCommandToolIntegrationTests.cs" />
+    <Compile Include="Integration/PermissionSessionBroadeningIntegrationTests.cs" />
     <!-- list_directory tool integration tests -->
     <Compile Include="Integration/ListDirectoryIntegrationTests.cs" />
     <!-- AQ1 headless config schema tests (rivoli-ai/andy-cli#46) -->

--- a/tests/Andy.Cli.Tests/Integration/PermissionSessionBroadeningIntegrationTests.cs
+++ b/tests/Andy.Cli.Tests/Integration/PermissionSessionBroadeningIntegrationTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Cli.Services;
+using Andy.Tools.Core;
+using Andy.Tools.Core.OutputLimiting;
+using Andy.Tools.Discovery;
+using Andy.Tools.Execution;
+using Andy.Tools.Framework;
+using Andy.Tools.Registry;
+using Andy.Tools.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Cli.Tests.Integration;
+
+/// <summary>
+/// End-to-end tests for the over-prompting fix, exercising the real CLI wiring
+/// (<see cref="CliPermissionServiceExtensions.AddAndyCliPermissions"/> -> interactive
+/// <see cref="CliPermissionPrompt"/> -> permission engine -> real <c>execute_command</c> tool). They prove
+/// that after one session "Allow" the user is NOT re-prompted for a similar command (same executable +
+/// subcommand, different args), but IS still prompted for a genuinely different command.
+/// </summary>
+[Collection("bash-tool-env")]
+public sealed class PermissionSessionBroadeningIntegrationTests
+{
+    /// <summary>Builds the CLI's real permission-gated executor wiring with an interactive broker.</summary>
+    private static ServiceProvider BuildProvider(PermissionRequestBroker broker)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddSingleton<IToolValidator, ToolValidator>();
+        services.AddSingleton<IToolRegistry, Andy.Tools.Registry.ToolRegistry>();
+        services.AddSingleton<IToolDiscovery, ToolDiscoveryService>();
+        services.AddSingleton<ISecurityManager, SecurityManager>();
+        services.AddSingleton<IResourceMonitor, ResourceMonitor>();
+        services.AddSingleton<IToolOutputLimiter, ToolOutputLimiter>();
+        services.AddSingleton<IToolExecutor, ToolExecutor>();
+        services.AddSingleton<IPermissionProfileService, PermissionProfileService>();
+        services.AddSingleton(new ToolFrameworkOptions
+        {
+            RegisterBuiltInTools = false,
+            EnableObservability = false,
+            AutoDiscoverTools = false,
+        });
+
+        ToolCatalog.RegisterAllTools(services);
+
+        // The exact wiring Program.cs uses (interactive prompt + broadening), with isolated file layers
+        // so the result is deterministic regardless of any user/project permission files on the machine.
+        services.AddAndyCliPermissions(broker, o =>
+        {
+            o.UserFilePath = null;
+            o.ProjectFilePath = null;
+            o.LocalFilePath = null;
+            o.ManagedFilePath = null;
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        var registry = sp.GetRequiredService<IToolRegistry>();
+        foreach (var reg in sp.GetServices<ToolRegistrationInfo>())
+        {
+            registry.RegisterTool(reg.ToolType, reg.Configuration);
+        }
+
+        return sp;
+    }
+
+    private static Dictionary<string, object?> Cmd(string command) => new() { ["command"] = command };
+
+    /// <summary>
+    /// Drains the broker on a background loop, answering every prompt with the given decision and counting
+    /// how many prompts were shown, until cancelled.
+    /// </summary>
+    private sealed class BrokerDriver : IDisposable
+    {
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+        public int PromptCount;
+
+        public BrokerDriver(PermissionRequestBroker broker, Andy.Permissions.Model.PermissionDecision decision)
+        {
+            _loop = Task.Run(async () =>
+            {
+                while (!_cts.IsCancellationRequested)
+                {
+                    if (broker.TryDequeue(out var pending) && pending != null)
+                    {
+                        Interlocked.Increment(ref PromptCount);
+                        pending.Completion.TrySetResult(decision);
+                    }
+                    else
+                    {
+                        await Task.Delay(5);
+                    }
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try { _loop.Wait(2000); } catch { /* best-effort shutdown */ }
+            _cts.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Allow_session_for_a_command_does_not_reprompt_for_a_similar_command()
+    {
+        var broker = new PermissionRequestBroker();
+        var allowSession = new Andy.Permissions.Model.PermissionDecision(
+            true, Andy.Permissions.Model.PersistScope.Session);
+        using var driver = new BrokerDriver(broker, allowSession);
+        using var sp = BuildProvider(broker);
+        var exec = new UiUpdatingToolExecutor(sp.GetRequiredService<IToolExecutor>());
+
+        // 'dotnet' is neutral (not on the engine's known-safe list) so the gate asks the first time.
+        var first = await exec.ExecuteAsync("execute_command", Cmd("dotnet help"), new ToolExecutionContext());
+        Assert.True(first.IsSuccessful, first.ErrorMessage);
+        Assert.Equal(1, driver.PromptCount);
+
+        // Different args, SAME command class (dotnet help): broadened session rule covers it -> no new prompt.
+        var second = await exec.ExecuteAsync("execute_command", Cmd("dotnet help build"), new ToolExecutionContext());
+        Assert.True(second.IsSuccessful, second.ErrorMessage);
+        Assert.Equal(1, driver.PromptCount);
+    }
+
+    [Fact]
+    public async Task Allow_session_does_not_authorize_a_genuinely_different_command()
+    {
+        var broker = new PermissionRequestBroker();
+        var allowSession = new Andy.Permissions.Model.PermissionDecision(
+            true, Andy.Permissions.Model.PersistScope.Session);
+        using var driver = new BrokerDriver(broker, allowSession);
+        using var sp = BuildProvider(broker);
+        var exec = new UiUpdatingToolExecutor(sp.GetRequiredService<IToolExecutor>());
+
+        await exec.ExecuteAsync("execute_command", Cmd("dotnet help"), new ToolExecutionContext());
+        Assert.Equal(1, driver.PromptCount);
+
+        // A different command class ('dotnet' with a flag, not the 'dotnet help' subcommand) is NOT covered
+        // by the 'dotnet help' grant -> a new prompt is shown.
+        await exec.ExecuteAsync("execute_command", Cmd("dotnet --info"), new ToolExecutionContext());
+        Assert.Equal(2, driver.PromptCount);
+    }
+}

--- a/tests/Andy.Cli.Tests/Services/CliPermissionSessionBroadeningTests.cs
+++ b/tests/Andy.Cli.Tests/Services/CliPermissionSessionBroadeningTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Linq;
+using Andy.Cli.Services;
+using Andy.Permissions.Model;
+using Andy.Permissions.Store;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services;
+
+/// <summary>
+/// Unit tests for the session-grant broadening that <see cref="CliPermissionPrompt"/> applies when a user
+/// picks "Allow (session)". The engine's own remembered rule pins the exact command line, which re-prompts
+/// for argument-only variations; the broadened rule is keyed to the command class (executable + first
+/// subcommand) so similar invocations are not re-prompted, while genuinely different commands still are.
+/// </summary>
+public class CliPermissionSessionBroadeningTests
+{
+    [Theory]
+    [InlineData("gh pr list --limit 10", "gh pr")]
+    [InlineData("git status", "git status")]
+    [InlineData("npm run build", "npm run")]
+    [InlineData("ls -la", "ls")]
+    [InlineData("/usr/bin/gh pr view 5", "gh pr")]   // executable leaf name only
+    [InlineData("FOO=bar gh pr list", "gh pr")]      // leading env assignment is skipped
+    [InlineData("dotnet --version", "dotnet")]       // first non-exe token is a flag => executable only
+    public void CommandClass_groups_by_executable_and_first_subcommand(string command, string expected)
+    {
+        Assert.Equal(expected, CliPermissionPrompt.CommandClass(command));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("| rm")]            // begins with a metacharacter => not a bare executable
+    [InlineData("$(whoami)")]       // command substitution => refuse to widen
+    public void CommandClass_returns_empty_when_no_safe_executable(string command)
+    {
+        Assert.Equal(string.Empty, CliPermissionPrompt.CommandClass(command));
+    }
+
+    [Fact]
+    public void Session_allow_installs_a_broadened_command_class_rule()
+    {
+        var store = new FakeStore();
+        var request = AskRequest("gh pr list --limit 10");
+
+        CliPermissionPrompt.GrantBroadenedSessionRules(request, store);
+
+        var rule = Assert.Single(store.SessionRules);
+        Assert.Equal("execute_command", rule.Tool);
+        Assert.Equal("gh pr:*", rule.Specifier);
+        Assert.Equal(PermissionOutcome.Allow, rule.Outcome);
+        Assert.Equal(PermissionLayer.Session, rule.Layer);
+    }
+
+    [Fact]
+    public void Broadened_rule_matches_similar_commands_but_not_unrelated_ones()
+    {
+        var store = new FakeStore();
+        CliPermissionPrompt.GrantBroadenedSessionRules(AskRequest("gh pr list --limit 10"), store);
+        var rule = Assert.Single(store.SessionRules);
+
+        // Same command class with different arguments: covered (no re-prompt).
+        Assert.True(MatchesCommand(rule.Specifier, "gh pr list --limit 20"));
+        Assert.True(MatchesCommand(rule.Specifier, "gh pr view 42"));
+
+        // A different subcommand or a different executable: NOT covered (still prompts).
+        Assert.False(MatchesCommand(rule.Specifier, "gh repo delete acme/widgets"));
+        Assert.False(MatchesCommand(rule.Specifier, "rm -rf /tmp/x"));
+    }
+
+    [Fact]
+    public void Only_command_resources_flagged_for_ask_are_broadened()
+    {
+        var store = new FakeStore();
+        var allowed = new EvaluatedResource(
+            new ResourceAccess(ResourceKind.Command, "git status"), PermissionOutcome.Allow, null, true);
+        var asked = new EvaluatedResource(
+            new ResourceAccess(ResourceKind.Command, "gh pr list"), PermissionOutcome.Ask, null, true);
+        var request = new PermissionRequest("execute_command", "Execute Command", "run",
+            new PermissionEvaluation(PermissionOutcome.Ask, new[] { allowed, asked }));
+
+        CliPermissionPrompt.GrantBroadenedSessionRules(request, store);
+
+        var rule = Assert.Single(store.SessionRules);
+        Assert.Equal("gh pr:*", rule.Specifier);   // only the Ask resource was broadened
+    }
+
+    [Fact]
+    public void No_store_is_a_safe_no_op()
+    {
+        // Should not throw when the store is unavailable (e.g. non-interactive wiring).
+        CliPermissionPrompt.GrantBroadenedSessionRules(AskRequest("gh pr list"), store: null);
+    }
+
+    private static bool MatchesCommand(string specifier, string command)
+        => Andy.Permissions.Matching.SpecifierMatcher.MatchCommand(specifier, command);
+
+    private static PermissionRequest AskRequest(string command)
+    {
+        var resource = new EvaluatedResource(
+            new ResourceAccess(ResourceKind.Command, command), PermissionOutcome.Ask, null, true);
+        return new PermissionRequest("execute_command", "Execute Command", command,
+            new PermissionEvaluation(PermissionOutcome.Ask, new[] { resource }));
+    }
+
+    /// <summary>Minimal <see cref="IPermissionStore"/> that records the session rules added to it.</summary>
+    private sealed class FakeStore : IPermissionStore
+    {
+        public List<PermissionRule> SessionRules { get; } = new();
+
+        public void AddSessionRule(PermissionRule rule) => SessionRules.Add(rule);
+
+        public IReadOnlyList<PermissionRule> GetRules() => SessionRules.ToList();
+
+        public System.Threading.Tasks.Task AppendRuleAsync(
+            string toolId, string specifier, PermissionOutcome outcome, PersistScope scope,
+            System.Threading.CancellationToken ct = default)
+            => System.Threading.Tasks.Task.CompletedTask;
+
+        public void SetInjectedRules(IEnumerable<PermissionRule> rules) { }
+    }
+}


### PR DESCRIPTION
## Problem
After a session "Allow", the permission system re-prompted for very similar commands. Root cause: a session Allow stored a rule keyed to the full command line with all arguments (e.g. `gh pr list --limit 10:*`), and matching is prefix-based, so `--limit 20` did not match and re-prompted.

## Change
- After a session Allow, `CliPermissionPrompt` additionally installs a broader session-scoped rule keyed to the command class = executable leaf + first subcommand (e.g. `gh pr`, `git status`, `npm run`; bare executable like `ls` if no subcommand).
- Safety: approving `gh pr list` does not authorize `gh repo delete` or a different executable; leading `VAR=value` is skipped; any token with shell metacharacters or command substitution refuses to widen. Grants are in-memory, session-only.

## Tests
New unit tests (command-class derivation, rule shape, match/no-match, no-op without a store) and an integration test proving a similar command is not re-prompted while a different class still prompts. Full suite green.

## Caveats
- The engine still writes its own narrow full-command session rule; the broader rule is added alongside (redundant but harmless).
- Broadening applies to interactive sessions where the store is wired; headless contexts are a safe no-op.
