### PR TITLE
Fix: stop the cd preamble on approved shell commands

### DIFF
--- a/src/Andy.Cli/Services/Prompts/SystemPromptBuilder.cs
+++ b/src/Andy.Cli/Services/Prompts/SystemPromptBuilder.cs
@@ -69,6 +69,12 @@ public class SystemPromptBuilder
         _prompt.AppendLine("- Run independent operations in parallel when possible");
         _prompt.AppendLine("- Always use tools when they can help fulfill the user's request rather than explaining what you would do");
         _prompt.AppendLine();
+        _prompt.AppendLine("**Running shell commands (execute_command):**");
+        _prompt.AppendLine("- The command already runs in the working directory shown in the Environment Context.");
+        _prompt.AppendLine("- Do NOT prepend a 'cd <dir> &&' preamble to the command. Pass the bare command only (for example 'gh pr list', not 'cd /path && gh pr list').");
+        _prompt.AppendLine("- To run a command in a DIFFERENT directory, set the tool's 'working_directory' parameter instead of using 'cd'.");
+        _prompt.AppendLine("- Keeping the command clean ensures the approval prompt and the executed command show exactly what will run, with no hidden directory change.");
+        _prompt.AppendLine();
 
         return this;
     }

--- a/tests/Andy.Cli.Tests/Integration/ExecuteCommandToolIntegrationTests.cs
+++ b/tests/Andy.Cli.Tests/Integration/ExecuteCommandToolIntegrationTests.cs
@@ -176,6 +176,32 @@ public sealed class ExecuteCommandToolIntegrationTests
     }
 
     [Fact]
+    public async Task Working_directory_parameter_runs_command_in_dir_without_cd_preamble()
+    {
+        // Proves the fix: a different run directory is selected via the tool's working_directory
+        // parameter (which sets ProcessStartInfo.WorkingDirectory) rather than a "cd <dir> &&" preamble
+        // on the command. The executed command stays clean, so the approval preview matches what runs.
+        using var sp = BuildProvider();
+        var exec = sp.GetRequiredService<IToolExecutor>();
+
+        var tempDir = System.IO.Path.GetTempPath().TrimEnd(System.IO.Path.DirectorySeparatorChar);
+
+        // "pwd" is known-safe; no "cd" appears anywhere in the command string.
+        var parameters = new Dictionary<string, object?>
+        {
+            ["command"] = "pwd",
+            ["working_directory"] = tempDir,
+        };
+        var result = await exec.ExecuteAsync("execute_command", parameters, Context());
+
+        var (ok, exit, stdout, err) = Read(result);
+        Assert.True(ok, err);
+        Assert.Equal(0, exit);
+        // The command ran in the requested directory even though it contained no "cd".
+        Assert.Contains(System.IO.Path.GetFileName(tempDir), stdout);
+    }
+
+    [Fact]
     public async Task Nonzero_exit_is_surfaced_as_failure()
     {
         using var sp = BuildProvider();

--- a/tests/Andy.Cli.Tests/Services/SystemPromptBuilderTests.cs
+++ b/tests/Andy.Cli.Tests/Services/SystemPromptBuilderTests.cs
@@ -25,6 +25,25 @@ public class SystemPromptBuilderTests
     }
 
     [Fact]
+    public void SystemPrompt_InstructsAgainstCdPreambleForShellCommands()
+    {
+        // Arrange
+        var builder = new SystemPromptBuilder();
+
+        // Act
+        var prompt = builder
+            .WithCoreMandates()
+            .WithWorkflowGuidelines()
+            .Build();
+
+        // Assert: the model must be told not to prepend a "cd <dir> &&" preamble and to use the
+        // execute_command working_directory parameter instead, so the approval prompt and executed
+        // command show the clean command only.
+        Assert.Contains("Do NOT prepend a 'cd <dir> &&' preamble", prompt);
+        Assert.Contains("set the tool's 'working_directory' parameter instead of using 'cd'", prompt);
+    }
+
+    [Fact]
     public void SystemPrompt_DistinguishesBetweenDisplayAndSave()
     {
         // Arrange


### PR DESCRIPTION
## Problem
When approving a `gh ...` (or other) shell command, the previewed/executed command included a leading `cd <dir> &&` preamble that obscured the actual command.

## Root cause
The `cd <dir> &&` is generated by the model in the `command` parameter itself, not by the executor or permission layer. `ExecuteCommandTool` passes the command straight to the shell and already honors a `working_directory` parameter (no `cd` injected); the approval preview already reflects exactly what runs. The system prompt showed the working directory but never told the model it could use the `working_directory` parameter.

## Change
- Adds guidance in `SystemPromptBuilder` instructing the model to pass the bare command and use the `working_directory` parameter instead of a `cd` preamble.

## Tests
A prompt-builder test asserting the anti-`cd` guidance is present, and an integration test proving a command runs in a chosen directory via `working_directory` with no `cd` in the command string. Full suite green.

## Caveats
- This is a prompt-level steer (the correct layer, since the `cd` originates with the model); it does not hard-strip a `cd` preamble at the executor. A belt-and-suspenders follow-up could detect/strip a leading `cd <dir> &&` in `UiUpdatingToolExecutor`, but that risks misparsing complex commands.
