### PR TITLE
Fix: snap feed to bottom when typing into the prompt

### DIFF
--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -1066,7 +1066,16 @@ class Program
                     }
 
                     // Avoid mapping regular alphanumeric keys to actions
+                    var textBeforeKey = prompt.Text;
                     var submitted = prompt.OnKey(k);
+                    // If the keystroke edited the prompt text (typing, paste, backspace,
+                    // delete, etc.), snap the feed back to the bottom where the prompt
+                    // lives. Pure navigation/scroll keys (arrows, Home/End, PgUp/PgDn,
+                    // wheel) do not change the text and therefore do not yank the view.
+                    if (!ReferenceEquals(submitted, null) || !string.Equals(prompt.Text, textBeforeKey, StringComparison.Ordinal))
+                    {
+                        feed.SnapToBottom();
+                    }
                     if (submitted is string cmd && !string.IsNullOrWhiteSpace(cmd) && !isProcessingMessage)
                     {
                         // Check for slash commands

--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -480,6 +480,21 @@ namespace Andy.Cli.Widgets
             return _scrollOffset;
         }
 
+        /// <summary>
+        /// Snap the view to the bottom and re-enable auto-scroll (pin to bottom).
+        /// Used when the user starts typing into the prompt: the feed should return
+        /// to where the prompt is, regardless of how far up they had scrolled.
+        /// This resets <see cref="_scrollOffset"/> to 0 and clears any pending hold
+        /// or idle-timer state so the feed follows new content again.
+        /// </summary>
+        public void SnapToBottom()
+        {
+            _scrollOffset = 0;
+            _followTail = true;
+            _autoScrollHoldAnchor = false;
+            _lastScrollActivityUtc = DateTime.MinValue;
+        }
+
         /// <summary>Advance animation state one frame.</summary>
         public void Tick()
         {

--- a/tests/Andy.Cli.Tests/Widgets/FeedViewAutoScrollTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/FeedViewAutoScrollTests.cs
@@ -182,6 +182,59 @@ public class FeedViewAutoScrollTests
     }
 
     [Fact]
+    public void SnapToBottom_WhenScrolledUp_ResetsOffsetAndReenablesAutoScroll()
+    {
+        var feed = new FeedView();
+        AddLines(feed, 100);
+        Render(feed);
+
+        feed.ScrollLines(20, Height); // user scrolled up reading history
+        Render(feed);
+        Assert.True(feed.ScrollOffset > FeedView.PinnedToBottomThresholdLines);
+        Assert.False(feed.IsAutoScrollEnabled);
+
+        // Simulates the user starting to type into the prompt.
+        feed.SnapToBottom();
+
+        Assert.Equal(0, feed.ScrollOffset);
+        Assert.True(feed.IsAutoScrollEnabled);
+    }
+
+    [Fact]
+    public void SnapToBottom_ThenAppend_FollowsNewContent()
+    {
+        var feed = new FeedView();
+        AddLines(feed, 100);
+        Render(feed);
+
+        feed.ScrollLines(20, Height);
+        Render(feed);
+        Assert.False(feed.IsAutoScrollEnabled);
+
+        feed.SnapToBottom();
+
+        // After snapping back, newly appended content follows the tail.
+        AddLines(feed, 25, startIndex: 100);
+        Render(feed);
+        Assert.Equal(0, feed.ScrollOffset);
+        Assert.True(feed.IsAutoScrollEnabled);
+    }
+
+    [Fact]
+    public void SnapToBottom_WhenAlreadyAtBottom_StaysAtBottom()
+    {
+        var feed = new FeedView();
+        AddLines(feed, 100);
+        Render(feed);
+        Assert.Equal(0, feed.ScrollOffset);
+
+        feed.SnapToBottom();
+
+        Assert.Equal(0, feed.ScrollOffset);
+        Assert.True(feed.IsAutoScrollEnabled);
+    }
+
+    [Fact]
     public void Clear_ResetsToAutoScrollAtBottom()
     {
         var feed = new FeedView();


### PR DESCRIPTION
## Problem
When the user had scrolled up to read history and then started typing, the view stayed scrolled up instead of returning to the prompt at the bottom.

## Change
- Adds `FeedView.SnapToBottom()` (resets scroll offset to bottom, re-enables auto-scroll, clears the hold/idle state), reusing the existing auto-scroll machinery.
- In the interactive input loop, captures `prompt.Text` before/after `OnKey` and calls `SnapToBottom()` only when the text actually changed or a line was submitted. This covers all text-editing keys (typing, paste, backspace, Ctrl+K/U) while excluding pure navigation/scroll keys (arrows, Home/End, PgUp/PgDn, wheel), with no hard-coded key whitelist.

## Tests
3 new FeedView tests (snap from scrolled-up resets offset + re-enables auto-scroll; snap then append follows tail; already-at-bottom no-op). Full suite green (406).
