### PR TITLE
Fix: reject malformed execute_command calls (e.g. command '1')

### DIFF
--- a/src/Andy.Cli/Services/Adapters/ToolAdapter.cs
+++ b/src/Andy.Cli/Services/Adapters/ToolAdapter.cs
@@ -134,6 +134,126 @@ public class ToolAdapter : Andy.Model.Tooling.ITool
         };
     }
 
+    /// <summary>
+    /// Identifies the shell execution tool regardless of which alias the model used.
+    /// </summary>
+    private static bool IsExecuteCommandTool(string toolId, string callName)
+    {
+        return string.Equals(toolId, "execute_command", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(callName, "execute_command", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns a human-readable reason if the supplied execute_command parameters describe a command that is
+    /// missing or degenerate (no runnable executable token), otherwise null. A "degenerate" command is one
+    /// that, after trimming, is empty or whose first non-assignment token is not a usable executable name
+    /// (for example a bare number such as "1", a flag, or a pure shell metacharacter). Such inputs are
+    /// symptoms of a mangled tool call and must never reach the permission prompt or the shell.
+    /// </summary>
+    internal static string? GetInvalidCommandReason(IReadOnlyDictionary<string, object?> parameters)
+    {
+        if (!parameters.TryGetValue("command", out var commandObj) || commandObj == null)
+        {
+            return "execute_command was called without a 'command' argument. Provide the full shell command to run.";
+        }
+
+        var command = commandObj.ToString() ?? string.Empty;
+        var trimmed = command.Trim();
+        if (trimmed.Length == 0)
+        {
+            return "execute_command was called with an empty 'command'. Provide the full shell command to run.";
+        }
+
+        if (!HasRunnableExecutable(trimmed))
+        {
+            return $"execute_command received a malformed command ('{command}') with no runnable executable. "
+                 + "This usually means the command was garbled (for example a numbered-list prefix). "
+                 + "Re-issue the call with the complete command, such as 'dotnet test'.";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines whether a command string begins with something that could plausibly be an executable: a
+    /// bare word that is not a number, not a flag, and not made of shell metacharacters. Leading
+    /// <c>VAR=value</c> environment assignments are skipped first.
+    /// </summary>
+    private static bool HasRunnableExecutable(string command)
+    {
+        var tokens = command.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        int i = 0;
+
+        // Skip leading environment assignments (FOO=bar) that precede the executable.
+        while (i < tokens.Length && IsEnvAssignment(tokens[i]))
+        {
+            i++;
+        }
+
+        if (i >= tokens.Length)
+        {
+            return false;
+        }
+
+        var token = tokens[i];
+
+        // A flag/option cannot be the executable.
+        if (token.StartsWith("-", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // A purely numeric token (e.g. "1" from a markdown list) is not a command.
+        if (IsAllDigits(token))
+        {
+            return false;
+        }
+
+        // Must contain at least one character usable in an executable name.
+        foreach (var c in token)
+        {
+            if (char.IsLetterOrDigit(c) || c == '/' || c == '\\' || c == '.' || c == '_' || c == '-')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsEnvAssignment(string token)
+    {
+        int eq = token.IndexOf('=');
+        if (eq <= 0)
+        {
+            return false;
+        }
+
+        for (int j = 0; j < eq; j++)
+        {
+            var c = token[j];
+            if (!char.IsLetterOrDigit(c) && c != '_')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsAllDigits(string token)
+    {
+        foreach (var c in token)
+        {
+            if (!char.IsDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return token.Length > 0;
+    }
+
     public async Task<Andy.Model.Model.ToolResult> ExecuteAsync(Andy.Model.Model.ToolCall call, CancellationToken ct = default)
     {
         try
@@ -148,6 +268,25 @@ public class ToolAdapter : Andy.Model.Tooling.ITool
             foreach (var kvp in rawParameters)
             {
                 parameters[kvp.Key] = ConvertJsonElement(kvp.Value);
+            }
+
+            // Reject degenerate shell invocations BEFORE prompting the user or executing anything.
+            // The upstream LLM/function-call parser can occasionally emit a mangled execute_command whose
+            // "command" argument is empty or a bare token with no executable (for example the literal "1"
+            // taken from a markdown numbered list such as "1. dotnet build"). Passing that straight through
+            // would (a) show a nonsensical permission prompt for the command "1" and (b) run garbage in the
+            // shell, where the OS can react in surprising ways. Fail fast with a clear message instead.
+            if (IsExecuteCommandTool(_toolId, call.Name))
+            {
+                var invalidReason = GetInvalidCommandReason(parameters);
+                if (invalidReason != null)
+                {
+                    _logger?.LogWarning("[TOOL_ADAPTER] Rejecting malformed execute_command call: {Reason}", invalidReason);
+                    return Andy.Model.Model.ToolResult.FromObject(
+                        call.Id, call.Name,
+                        new { error = invalidReason },
+                        isError: true);
+                }
             }
 
             // Log what we're about to do
@@ -287,7 +426,7 @@ public class ToolAdapter : Andy.Model.Tooling.ITool
                 // Try to use Data if available, otherwise use Message
                 object? resultData = result.Data;
 
-                 if (resultData == null && !string.IsNullOrEmpty(result.Message))
+                if (resultData == null && !string.IsNullOrEmpty(result.Message))
                 {
                     resultData = new { message = result.Message };
                 }

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="TestHelpers/TestCompatibilityShims.cs" />
     <Compile Include="VersionInfoTests.cs" />
     <Compile Include="Commands/ModelCommandTests.cs" />
+    <Compile Include="Themes/ThemeStateCollection.cs" />
     <Compile Include="Themes/ThemeSwitchingTests.cs" />
     <Compile Include="Services/ProviderDetectionServiceTests.cs" />
     <Compile Include="Services/SystemPromptBuilderTests.cs" />
@@ -71,6 +72,7 @@
     <Compile Include="Services/ParallelToolExecutionTests.cs" />
     <Compile Include="Services/CliPermissionPromptTests.cs" />
     <Compile Include="Services/CliPermissionSessionBroadeningTests.cs" />
+    <Compile Include="Services/ToolAdapterCommandGuardTests.cs" />
     <!-- ACP integration tests -->
     <Compile Include="ACP/AndyAgentProviderTests.cs" />
     <!-- Multi-turn conversation context tests -->

--- a/tests/Andy.Cli.Tests/Services/ToolAdapterCommandGuardTests.cs
+++ b/tests/Andy.Cli.Tests/Services/ToolAdapterCommandGuardTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using Andy.Cli.Services.Adapters;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services;
+
+/// <summary>
+/// Locks the guard that stops a mangled execute_command call (whose "command" argument is missing, empty, or
+/// a degenerate token such as the literal "1") from reaching the permission prompt and the shell. The "1"
+/// case reproduces the reported bug where asking the assistant to "run the tests" produced a permission
+/// prompt for the command "1" and, on approval, an unexpected shell side effect.
+/// </summary>
+public class ToolAdapterCommandGuardTests
+{
+    private static Dictionary<string, object?> Args(params (string Key, object? Value)[] kvps)
+    {
+        var d = new Dictionary<string, object?>();
+        foreach (var (k, v) in kvps)
+        {
+            d[k] = v;
+        }
+
+        return d;
+    }
+
+    [Fact]
+    public void Rejects_bare_numeric_command()
+    {
+        // The reported regression: a markdown numbered-list prefix ("1.") leaking through as the command.
+        var reason = ToolAdapter.GetInvalidCommandReason(Args(("command", "1")));
+        Assert.NotNull(reason);
+        Assert.Contains("malformed", reason!);
+    }
+
+    [Theory]
+    [InlineData("42")]
+    [InlineData("  7  ")]
+    public void Rejects_other_pure_number_commands(string command)
+    {
+        Assert.NotNull(ToolAdapter.GetInvalidCommandReason(Args(("command", command))));
+    }
+
+    [Fact]
+    public void Rejects_missing_command_argument()
+    {
+        var reason = ToolAdapter.GetInvalidCommandReason(Args(("working_directory", "/tmp")));
+        Assert.NotNull(reason);
+        Assert.Contains("without a 'command'", reason!);
+    }
+
+    [Fact]
+    public void Rejects_null_command_argument()
+    {
+        Assert.NotNull(ToolAdapter.GetInvalidCommandReason(Args(("command", null))));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Rejects_empty_command(string command)
+    {
+        var reason = ToolAdapter.GetInvalidCommandReason(Args(("command", command)));
+        Assert.NotNull(reason);
+        Assert.Contains("empty", reason!);
+    }
+
+    [Fact]
+    public void Rejects_command_that_is_only_a_flag()
+    {
+        Assert.NotNull(ToolAdapter.GetInvalidCommandReason(Args(("command", "--help"))));
+    }
+
+    [Theory]
+    [InlineData("dotnet test")]
+    [InlineData("dotnet build")]
+    [InlineData("ls -la")]
+    [InlineData("gh pr list --limit 10")]
+    [InlineData("/usr/bin/env python script.py")]
+    [InlineData("git status")]
+    [InlineData("FOO=bar dotnet test")] // leading env assignment, real executable after it
+    [InlineData("./run.sh")]
+    public void Accepts_well_formed_commands(string command)
+    {
+        Assert.Null(ToolAdapter.GetInvalidCommandReason(Args(("command", command))));
+    }
+}

--- a/tests/Andy.Cli.Tests/Themes/ThemeStateCollection.cs
+++ b/tests/Andy.Cli.Tests/Themes/ThemeStateCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Andy.Cli.Tests.Themes;
+
+/// <summary>
+/// Tests that read or mutate the process-wide <see cref="Andy.Cli.Themes.Theme.Current"/> singleton must not
+/// run concurrently with one another: xUnit parallelizes distinct test classes, so two such classes racing on
+/// the shared static caused intermittent failures (a render reading a theme another test had just reset).
+/// Marking the affected classes with this collection forces them to run sequentially.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class ThemeStateCollection
+{
+    public const string Name = "ThemeState";
+}

--- a/tests/Andy.Cli.Tests/Themes/ThemeSwitchingTests.cs
+++ b/tests/Andy.Cli.Tests/Themes/ThemeSwitchingTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Andy.Cli.Tests.Themes;
 
+[Collection(ThemeStateCollection.Name)]
 public class ThemeSwitchingTests
 {
     // ----- Theme lookup by name -----

--- a/tests/Andy.Cli.Tests/Widgets/PromptLineColorTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/PromptLineColorTests.cs
@@ -12,6 +12,7 @@ namespace Andy.Cli.Tests.Widgets;
 /// dedicated, high-contrast <see cref="Theme.PromptText"/> color rather than the
 /// lower-contrast accent color, and that the choice stays readable across themes.
 /// </summary>
+[Collection(Andy.Cli.Tests.Themes.ThemeStateCollection.Name)]
 public class PromptLineColorTests
 {
     private static DL.TextRun? FindRun(DL.DisplayList dl, string content)


### PR DESCRIPTION
## Problem
Asking the app to run tests could produce a permission prompt to run the command `1` (literally), and approving it ran garbage in the shell (observed opening a browser to docs as an OS side effect).

## Root cause (evidence-backed)
A malformed `execute_command` tool call with `command="1"` flows verbatim through the CLI: arguments arrive as `call.ArgumentsJson` in `ToolAdapter`, pass to the permission-gated executor, and the approval string is just that `command`. There is no browser code anywhere in the CLI - the browser was a downstream OS/shell side effect of executing junk. The mangling originates upstream in Andy.Llm's function-call argument parsing (reproduced: `JsonRepairSharp.RepairJson("1")` returns `1`, so a stray numbered-list token can survive as the command).

## Change
Since the upstream library cannot be patched here, adds a defensive guard at the CLI boundary (`ToolAdapter.ExecuteAsync`): degenerate `execute_command` calls (missing/empty command, bare numbers like `1`, flag-only, or only shell metacharacters; leading `VAR=value` skipped) are rejected with a clear error returned to the LLM, before any prompt or execution.

## Tests
16 guard tests (rejects `1`/other pure numbers, missing/null/empty, flag-only; accepts `dotnet test`, `ls -la`, `gh pr list --limit 10`, `FOO=bar dotnet test`, `./run.sh`). Also serializes two theme tests that mutate the global `Theme.Current` into a shared non-parallel collection (fixes a pre-existing race exposed by scheduling). Full suite green (419, verified 3x).
