### PR TITLE
Fix: ESC cancels the in-flight agent turn instead of quitting

### DIFF
--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -228,6 +228,7 @@ class Program
             var statusMessage = new StatusMessage();
             var prompt = new PromptLine();
             bool isProcessingMessage = false; // Track if we're processing a message
+            CancellationTokenSource? turnCts = null; // Cancels the in-flight agent turn when ESC is pressed
             prompt.SetBorder(true);
             prompt.SetShowCaret(true);
             prompt.SetFocused(true);
@@ -926,7 +927,15 @@ class Program
                             return;
                         }
 
-                        // Show exit confirmation dialog
+                        // If a turn is actively running, ESC cancels the in-flight
+                        // agent turn instead of quitting the app.
+                        if (isProcessingMessage)
+                        {
+                            turnCts?.Cancel();
+                            return;
+                        }
+
+                        // Idle: show exit confirmation dialog
                         if (await ShowExitConfirmationAsync())
                         {
                             running = false;
@@ -1255,21 +1264,30 @@ class Program
 
                         if (aiService != null)
                         {
-                            // Run the assistant processing on a background task so UI can update
+                            // Run the assistant processing on a background task so UI can update.
+                            // A per-turn CancellationTokenSource lets ESC cancel the in-flight turn.
+                            var cts = new CancellationTokenSource();
+                            turnCts = cts;
                             isProcessingMessage = true;
                             prompt.SetShowCaret(false); // Hide cursor during processing
                             _ = Task.Run(async () =>
                             {
                                 try
                                 {
-                                    statusMessage.SetMessage("Thinking", animated: true);
+                                    statusMessage.SetMessage("Thinking (ESC to cancel)", animated: true);
 
                                     // Process message with tool support (streaming disabled until properly implemented)
-                                    var response = await aiService.ProcessMessageAsync(cmd, enableStreaming: false);
+                                    var response = await aiService.ProcessMessageAsync(cmd, enableStreaming: false, cts.Token);
 
                                     // Token counter is now updated in real-time by SimpleAssistantService
 
                                     statusMessage.SetMessage("Ready for next question", animated: false);
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    // ESC cancelled the turn: surface a brief message and stay responsive.
+                                    feed.AddMarkdownRich("Cancelled.");
+                                    statusMessage.SetMessage("Cancelled", animated: false);
                                 }
                                 catch (Exception ex)
                                 {
@@ -1280,6 +1298,8 @@ class Program
                                 {
                                     isProcessingMessage = false;
                                     prompt.SetShowCaret(true); // Show cursor again when done
+                                    turnCts = null;
+                                    cts.Dispose();
                                 }
                             });
                         }

--- a/src/Andy.Cli/Services/SimpleAssistantService.cs
+++ b/src/Andy.Cli/Services/SimpleAssistantService.cs
@@ -472,6 +472,15 @@ public class SimpleAssistantService : IDisposable
 
             return result.Response ?? string.Empty;
         }
+        catch (OperationCanceledException)
+        {
+            // The turn was cancelled (e.g. user pressed ESC). Clear transient UI and
+            // rethrow so the caller can surface a "Cancelled." message instead of
+            // treating the cancellation as a failure.
+            _feed.ClearProcessingIndicator();
+            _logger?.LogInformation("Message processing cancelled by user");
+            throw;
+        }
         catch (Exception ex)
         {
             // Clear the processing indicator if an error occurred

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -92,6 +92,8 @@
     <Compile Include="Headless/HeadlessAgentRunnerStabilityTests.cs" />
     <!-- AQ8 headless contract validation library (rivoli-ai/andy-cli#54) -->
     <Compile Include="HeadlessConfig/HeadlessConfigContractTests.cs" />
+    <!-- ESC cancels in-flight agent turn (fix/esc-cancels-turn) -->
+    <Compile Include="Services/SimpleAssistantServiceCancellationTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Cli.Tests/Services/SimpleAssistantServiceCancellationTests.cs
+++ b/tests/Andy.Cli.Tests/Services/SimpleAssistantServiceCancellationTests.cs
@@ -1,0 +1,106 @@
+// Verifies that SimpleAssistantService honors cooperative cancellation: when the
+// per-turn CancellationToken is cancelled (the same signal the interactive ESC key
+// produces in Program.cs), ProcessMessageAsync surfaces an OperationCanceledException
+// rather than swallowing it into an error string. The interactive run loop relies on
+// this exception propagating so it can show "Cancelled." and stay responsive instead
+// of quitting the app.
+
+using System.Runtime.CompilerServices;
+using Andy.Cli.Services;
+using Andy.Cli.Widgets;
+using Andy.Model.Llm;
+using Andy.Model.Model;
+using Andy.Tools.Core;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services;
+
+public class SimpleAssistantServiceCancellationTests
+{
+    private static SimpleAssistantService CreateService(ILlmProvider provider)
+    {
+        var toolRegistry = new Mock<IToolRegistry>();
+        var noTools = new List<ToolRegistration>();
+        toolRegistry.Setup(x => x.Tools).Returns(noTools);
+        toolRegistry
+            .Setup(x => x.GetTools(
+                It.IsAny<ToolCategory?>(),
+                It.IsAny<ToolCapability?>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<bool>()))
+            .Returns(noTools);
+        var toolExecutor = new Mock<IToolExecutor>();
+        var feed = new FeedView();
+        var logger = new Mock<ILogger<SimpleAssistantService>>();
+
+        return new SimpleAssistantService(
+            provider,
+            toolRegistry.Object,
+            toolExecutor.Object,
+            feed,
+            "test-model",
+            "test-provider",
+            tokenCounter: null,
+            logger: logger.Object);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_WhenTokenAlreadyCancelled_ThrowsOperationCanceled()
+    {
+        var service = CreateService(new BlockUntilCancelledLlmProvider());
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.ProcessMessageAsync("Hello", enableStreaming: false, cts.Token));
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_WhenTokenCancelledMidRun_ThrowsOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        // Trip the cancel as soon as the provider call begins, mirroring an ESC
+        // press while the agent loop is in-flight.
+        var service = CreateService(new BlockUntilCancelledLlmProvider(onEnter: cts.Cancel));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.ProcessMessageAsync("Hello", enableStreaming: false, cts.Token));
+    }
+
+    // Mirrors a real provider's reaction to a cancelled token: it blocks on the
+    // token and surfaces OperationCanceledException when the token fires.
+    private sealed class BlockUntilCancelledLlmProvider : ILlmProvider
+    {
+        private readonly Action? _onEnter;
+
+        public BlockUntilCancelledLlmProvider(Action? onEnter = null)
+        {
+            _onEnter = onEnter;
+        }
+
+        public string Name => "stub";
+
+        public async Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken cancellationToken = default)
+        {
+            _onEnter?.Invoke();
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            throw new InvalidOperationException("Unreachable: provider should be cancelled.");
+        }
+
+        public async IAsyncEnumerable<LlmStreamResponse> StreamCompleteAsync(
+            LlmRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            yield break;
+        }
+
+        public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public Task<IEnumerable<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Enumerable.Empty<ModelInfo>());
+    }
+}


### PR DESCRIPTION
## Problem
Pressing ESC quit the app even while the engine was processing a turn. Desired: ESC cancels the in-flight agent turn while running; idle ESC keeps the existing quit behavior.

## Change
- Adds a per-turn `CancellationTokenSource`. The interactive loop reads input on the main thread while the turn runs on a background task, so ESC is still observed during processing; when a turn is running, ESC cancels the CTS (and does not quit). The token is passed into `ProcessMessageAsync`; the engine is already cooperatively cancellable.
- The background task catches `OperationCanceledException`, prints `Cancelled.`, and resets state in `finally`. Status hint shows `Thinking (ESC to cancel)` while running.
- Fixes a latent bug: `SimpleAssistantService.ProcessMessageAsync` had a broad catch that masked cancellation as an error string; it now rethrows `OperationCanceledException`.

## Tests
New cancellation tests (already-cancelled token and mid-run cancellation both propagate `OperationCanceledException`). Full suite green (405).

## Notes
- The bottom hints bar label was intentionally not rewritten per-frame (mode-dependent, would conflict with concurrent loop edits); the in-context cue is shown via the status line instead.
