### PR TITLE
Bump Andy.Llm to 2026.6.7-rc.38 (tool-argument JSON repair)

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -27,9 +27,9 @@
   <ItemGroup>
     <PackageReference Include="Andy.Acp.Core" Version="2025.11.18-rc.3" />
     <PackageReference Include="Andy.Engine" Version="2026.5.30-rc.33" />
-    <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
+    <PackageReference Include="Andy.Llm" Version="2026.6.7-rc.38" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
-    <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
+    <PackageReference Include="Andy.Model" Version="2026.5.31-rc.8" />
     <PackageReference Include="Andy.Permissions" Version="2026.6.4-rc.6" />
     <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.24" />
     <PackageReference Include="Andy.Tui" Version="2026.5.29-rc.43" />


### PR DESCRIPTION
Bumps `Andy.Llm` `2026.5.29-rc.31` -> `2026.6.7-rc.38`, the upstream root-cause fix for malformed tool-call arguments.

The new Andy.Llm normalizes tool-call arguments at every provider boundary: markdown fences, single quotes, trailing commas, double-encoded objects, and degenerate scalars (e.g. a bare `1`) are repaired into a valid arguments object before they reach the tool layer. This is the upstream complement to the CLI-side guard that defensively rejects malformed `execute_command` calls.

`Andy.Model` is bumped `2025.10.29-rc.5` -> `2026.5.31-rc.8` to satisfy the new Andy.Llm minimum (otherwise `NU1605` package-downgrade error).

## Tests

Full suite green: **403 passed, 1 skipped, 0 failed**. Release build clean.