### PR TITLE
Theme management: popular themes, transparent-background toggle, live theme switching

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -27,9 +27,9 @@
   <ItemGroup>
     <PackageReference Include="Andy.Acp.Core" Version="2025.11.18-rc.3" />
     <PackageReference Include="Andy.Engine" Version="2026.5.30-rc.33" />
-    <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
+    <PackageReference Include="Andy.Llm" Version="2026.6.7-rc.38" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
-    <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
+    <PackageReference Include="Andy.Model" Version="2026.5.31-rc.8" />
     <PackageReference Include="Andy.Permissions" Version="2026.6.4-rc.6" />
     <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.24" />
     <PackageReference Include="Andy.Tui" Version="2026.5.29-rc.43" />

--- a/src/Andy.Cli/Commands/ThemeCommand.cs
+++ b/src/Andy.Cli/Commands/ThemeCommand.cs
@@ -16,7 +16,7 @@ public class ThemeCommand : ICommand
     private readonly ThemeMemoryService _themeMemory;
 
     public string Name => "theme";
-    public string Description => "List and switch the UI theme";
+    public string Description => "List, switch, or toggle transparency of the UI theme";
     public string[] Aliases => new[] { "/theme", "themes" };
 
     public ThemeCommand() : this(new ThemeMemoryService())
@@ -35,6 +35,12 @@ public class ThemeCommand : ICommand
             return Task.FromResult(ListThemes());
         }
 
+        var first = args[0].Trim().ToLowerInvariant();
+        if (first is "transparent" or "transparency")
+        {
+            return Task.FromResult(ToggleTransparent(args.Length > 1 ? args[1] : null));
+        }
+
         return Task.FromResult(SwitchTheme(args[0]));
     }
 
@@ -45,10 +51,25 @@ public class ThemeCommand : ICommand
         result.AppendLine("----------------");
         foreach (var name in Theme.AvailableThemes)
         {
-            var marker = string.Equals(name, Theme.Current.Name, StringComparison.OrdinalIgnoreCase)
-                ? " (current)"
-                : "";
-            result.AppendLine($"  {name}{marker}");
+            var theme = Theme.GetByName(name);
+            var isCurrent = string.Equals(name, Theme.Current.Name, StringComparison.OrdinalIgnoreCase);
+            var marker = isCurrent ? " (current)" : "";
+            var transparentTag = theme is { OffersTransparentBackground: true } ? "  [offers transparent bg]" : "";
+            result.AppendLine($"  {name}{marker}{transparentTag}");
+        }
+        result.AppendLine();
+
+        // Transparent-background "check" for the active theme.
+        var current = Theme.Current;
+        if (current.OffersTransparentBackground)
+        {
+            var check = current.HasTransparentBackground ? "[x]" : "[ ]";
+            result.AppendLine($"Transparent background: {check} {(current.HasTransparentBackground ? "on" : "off")}");
+            result.AppendLine("Toggle with: /theme transparent on|off");
+        }
+        else
+        {
+            result.AppendLine("Transparent background: not available for this theme");
         }
         result.AppendLine();
         result.AppendLine("Usage: /theme <name>");
@@ -57,16 +78,46 @@ public class ThemeCommand : ICommand
 
     private CommandResult SwitchTheme(string requested)
     {
-        var theme = Theme.GetByName(requested);
-        if (theme == null)
+        var baseTheme = Theme.GetByName(requested);
+        if (baseTheme == null)
         {
             var available = string.Join(", ", Theme.AvailableThemes);
             return CommandResult.Failure(
                 $"Unknown theme: '{requested}'. Available themes: {available}");
         }
 
-        Theme.Current = theme;
-        _themeMemory.SaveTheme(theme.Name);
-        return CommandResult.CreateSuccess($"Theme switched to '{theme.Name}'.");
+        // Carry the user's transparent-background preference onto the new theme
+        // (only applied when the new theme offers it).
+        var transparentPref = _themeMemory.LoadTransparentBackground();
+        var applied = Theme.Resolve(baseTheme.Name, transparentPref) ?? baseTheme;
+        Theme.Current = applied;
+        _themeMemory.SaveTheme(applied.Name);
+
+        var note = applied.HasTransparentBackground ? " (transparent background)" : "";
+        return CommandResult.CreateSuccess($"Theme switched to '{applied.Name}'.{note}");
+    }
+
+    private CommandResult ToggleTransparent(string? value)
+    {
+        var baseTheme = Theme.GetByName(Theme.Current.Name) ?? Theme.Dark;
+        if (!baseTheme.OffersTransparentBackground)
+        {
+            return CommandResult.Failure(
+                $"Theme '{baseTheme.Name}' does not offer a transparent background.");
+        }
+
+        bool enable = value?.Trim().ToLowerInvariant() switch
+        {
+            "on" or "true" or "yes" or "1" or "enable" or "enabled" => true,
+            "off" or "false" or "no" or "0" or "disable" or "disabled" => false,
+            _ => !Theme.Current.HasTransparentBackground // no/blank arg: toggle current state
+        };
+
+        Theme.Current = enable ? baseTheme.WithTransparentBackground() : baseTheme;
+        _themeMemory.SaveTransparentBackground(enable);
+
+        var check = enable ? "[x]" : "[ ]";
+        return CommandResult.CreateSuccess(
+            $"Transparent background {check} {(enable ? "enabled" : "disabled")} for '{baseTheme.Name}'.");
     }
 }

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -1354,10 +1354,17 @@ class Program
                 // Render placeholder + CLI widgets
                 var b = new DL.DisplayListBuilder();
                 b.PushClip(new DL.ClipPush(0, 0, viewport.Width, viewport.Height));
-                // No background rectangle - use transparent terminal background
+
+                var theme = Andy.Cli.Themes.Theme.Current;
+                // Opaque themes paint a full-surface background so switching themes
+                // recolors the whole screen; transparent themes leave it unpainted so
+                // the terminal background (including its transparency) shows through.
+                if (!theme.HasTransparentBackground && theme.Background is { } surfaceBg)
+                {
+                    b.DrawRect(new DL.Rect(0, 0, viewport.Width, viewport.Height, surfaceBg));
+                }
 
                 // Draw header with full-width background
-                var theme = Andy.Cli.Themes.Theme.Current;
                 b.DrawRect(new DL.Rect(0, 0, viewport.Width, 1, theme.HeaderBackground));
 
                 // Prepare header components
@@ -1602,16 +1609,18 @@ class Program
                     }
                 }
 
-                // Main surface: transparent. Drop any fill/bg a widget hardcoded so the
-                // terminal background shows through the UI (e.g. message blocks that bake
-                // in a black background).
+                // Main surface. For a transparent theme, drop any fill/bg a widget
+                // hardcoded so the terminal background shows through (e.g. message blocks
+                // that bake in a black background). For an opaque theme, keep the
+                // backgrounds so switching themes actually recolors the surface.
                 static void Append(object op, DL.DisplayListBuilder b)
                 {
+                    bool transparent = Andy.Cli.Themes.Theme.Current.HasTransparentBackground;
                     switch (op)
                     {
-                        case DL.Rect r: b.DrawRect(r with { Fill = null }); break;
+                        case DL.Rect r: b.DrawRect(transparent ? r with { Fill = null } : r); break;
                         case DL.Border br: b.DrawBorder(br); break;
-                        case DL.TextRun tr: b.DrawText(tr with { Bg = null }); break;
+                        case DL.TextRun tr: b.DrawText(transparent ? tr with { Bg = null } : tr); break;
                         case DL.ClipPush cp: b.PushClip(cp); break;
                         case DL.LayerPush lp: b.PushLayer(lp); break;
                         case DL.Pop: b.Pop(); break;

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -162,7 +162,7 @@ class Program
         var themeMemory = new ThemeMemoryService();
         var savedThemeName = themeMemory.LoadTheme()
             ?? Environment.GetEnvironmentVariable("ANDY_THEME");
-        var savedTheme = Andy.Cli.Themes.Theme.GetByName(savedThemeName);
+        var savedTheme = Andy.Cli.Themes.Theme.Resolve(savedThemeName, themeMemory.LoadTransparentBackground());
         if (savedTheme != null)
         {
             Andy.Cli.Themes.Theme.Current = savedTheme;
@@ -241,7 +241,7 @@ class Program
             {
                 new InlineCommandHelp.CommandInfo { Name = "model", Description = "Manage AI models (list, switch, info, test)", Aliases = new[] { "m" } },
                 new InlineCommandHelp.CommandInfo { Name = "tools", Description = "Manage and list available tools", Aliases = new[] { "tool", "t" } },
-                new InlineCommandHelp.CommandInfo { Name = "theme", Description = "List and switch the UI theme", Aliases = new[] { "themes" } },
+                new InlineCommandHelp.CommandInfo { Name = "theme", Description = "List, switch, or toggle transparency of the UI theme", Aliases = new[] { "themes" } },
                 new InlineCommandHelp.CommandInfo { Name = "clear", Description = "Clear conversation history", Aliases = Array.Empty<string>() },
                 new InlineCommandHelp.CommandInfo { Name = "help", Description = "Show help information", Aliases = new[] { "?" } },
                 new InlineCommandHelp.CommandInfo { Name = "exit", Description = "Exit the application", Aliases = new[] { "quit", "bye" } }
@@ -715,7 +715,8 @@ class Program
                             "- **/model test [prompt]**: Test current model\n\n" +
                             "### Theme Commands:\n" +
                             "- **/theme**: List available themes and the current one\n" +
-                            "- **/theme <name>**: Switch the UI theme (e.g. dark, light)\n\n" +
+                            "- **/theme <name>**: Switch the UI theme (e.g. dark, dracula, nord)\n" +
+                            "- **/theme transparent on|off**: Toggle the transparent background\n\n" +
                             "### Tool Commands:\n" +
                             "- **/tools list [category]**: List available tools\n" +
                             "- **/tools info <tool_name>**: Show tool details\n" +
@@ -1181,7 +1182,8 @@ class Program
                                         "- **/model test [prompt]**: Test current model\n\n" +
                                         "### Theme Commands:\n" +
                                         "- **/theme**: List available themes and the current one\n" +
-                                        "- **/theme <name>**: Switch the UI theme (e.g. dark, light)\n\n" +
+                                        "- **/theme <name>**: Switch the UI theme (e.g. dark, dracula, nord)\n" +
+                                        "- **/theme transparent on|off**: Toggle the transparent background\n\n" +
                                         "### Tool Commands:\n" +
                                         "- **/tools list [category]**: List available tools\n" +
                                         "- **/tools info <tool_name>**: Show tool details\n" +

--- a/src/Andy.Cli/Services/ThemeMemoryService.cs
+++ b/src/Andy.Cli/Services/ThemeMemoryService.cs
@@ -43,15 +43,23 @@ public class ThemeMemoryService
     }
 
     /// <summary>
-    /// Persist the selected theme name.
+    /// Persist the selected theme name, preserving the saved transparent-background
+    /// preference.
     /// </summary>
-    public void SaveTheme(string themeName)
+    public void SaveTheme(string themeName) => SaveTheme(themeName, LoadTransparentBackground());
+
+    /// <summary>
+    /// Persist the selected theme name together with the transparent-background
+    /// preference.
+    /// </summary>
+    public void SaveTheme(string themeName, bool transparentBackground)
     {
         try
         {
             var memory = new ThemeMemory
             {
                 Theme = themeName,
+                TransparentBackground = transparentBackground,
                 LastUsed = DateTime.UtcNow
             };
             var json = JsonSerializer.Serialize(memory, new JsonSerializerOptions
@@ -65,6 +73,12 @@ public class ThemeMemoryService
             // Silently fail if we can't save
         }
     }
+
+    /// <summary>
+    /// Persist only the transparent-background preference, keeping the saved theme name.
+    /// </summary>
+    public void SaveTransparentBackground(bool transparentBackground)
+        => SaveTheme(LoadTheme() ?? "", transparentBackground);
 
     /// <summary>
     /// Load the previously selected theme name, or null when none was saved.
@@ -87,9 +101,31 @@ public class ThemeMemoryService
         return null;
     }
 
+    /// <summary>
+    /// Load the persisted transparent-background preference (false when none saved).
+    /// </summary>
+    public bool LoadTransparentBackground()
+    {
+        try
+        {
+            if (File.Exists(_configPath))
+            {
+                var json = File.ReadAllText(_configPath);
+                var memory = JsonSerializer.Deserialize<ThemeMemory>(json);
+                return memory?.TransparentBackground ?? false;
+            }
+        }
+        catch
+        {
+            // If loading fails, behave as if nothing was saved
+        }
+        return false;
+    }
+
     private class ThemeMemory
     {
         public string Theme { get; set; } = "";
+        public bool TransparentBackground { get; set; }
         public DateTime LastUsed { get; set; }
     }
 }

--- a/src/Andy.Cli/Themes/Theme.cs
+++ b/src/Andy.Cli/Themes/Theme.cs
@@ -28,6 +28,12 @@ namespace Andy.Cli.Themes
         public DL.Rgb24 StatusLineBackground { get; set; } = new DL.Rgb24(10, 10, 10);
         public DL.Rgb24 KeyHintsBackground { get; set; } = new DL.Rgb24(15, 15, 15);
 
+        // Whether this theme offers the optional transparent-background mode (the
+        // main surfaces become null so the terminal background shows through). Dark
+        // themes opt in; light-background themes opt out because their dark text is
+        // unreadable when a dark terminal shows through.
+        public bool OffersTransparentBackground { get; set; } = true;
+
         // Foreground/Text colors
         public DL.Rgb24 Text { get; set; } = new DL.Rgb24(220, 220, 220);
         public DL.Rgb24 TextDim { get; set; } = new DL.Rgb24(150, 150, 150);
@@ -81,6 +87,31 @@ namespace Andy.Cli.Themes
         public DL.Rgb24 ToolName { get; set; } = new DL.Rgb24(255, 200, 100);
         public DL.Rgb24 ToolRunning { get; set; } = new DL.Rgb24(100, 150, 255);
         public DL.Rgb24 ToolResult { get; set; } = new DL.Rgb24(180, 180, 180);
+
+        /// <summary>
+        /// True when all four main surfaces are transparent (terminal shows through).
+        /// </summary>
+        public bool HasTransparentBackground =>
+            Background is null && HeaderBackground is null
+            && DialogBackground is null && PromptBackground is null;
+
+        /// <summary>Create a shallow copy of this theme (all colors are value types).</summary>
+        public Theme Clone() => (Theme)MemberwiseClone();
+
+        /// <summary>
+        /// Return a copy with the main surfaces made transparent so the terminal
+        /// background shows through. Chrome surfaces (status line, key hints, toast,
+        /// code block) keep a shade for legibility.
+        /// </summary>
+        public Theme WithTransparentBackground()
+        {
+            var t = Clone();
+            t.Background = null;
+            t.HeaderBackground = null;
+            t.DialogBackground = null;
+            t.PromptBackground = null;
+            return t;
+        }
 
         /// <summary>
         /// Default dark theme.
@@ -144,21 +175,143 @@ namespace Andy.Cli.Themes
             ToolResult = new DL.Rgb24(90, 90, 90),
         };
 
+        private static DL.Rgb24 Hex(string hex)
+        {
+            int o = hex.Length > 0 && hex[0] == '#' ? 1 : 0;
+            byte r = Convert.ToByte(hex.Substring(o, 2), 16);
+            byte g = Convert.ToByte(hex.Substring(o + 2, 2), 16);
+            byte b = Convert.ToByte(hex.Substring(o + 4, 2), 16);
+            return new DL.Rgb24(r, g, b);
+        }
+
+        /// <summary>
+        /// Build a theme from a compact core palette (popular vim/terminal schemes).
+        /// The core colors are mapped to the application's semantic roles consistently
+        /// across all ported themes.
+        /// </summary>
+        private static Theme FromPalette(string name,
+            string bg, string bg1, string bg2, string sel, string fg, string dim, string accent,
+            string red, string green, string yellow, string blue, string magenta, string cyan,
+            bool offersTransparency = true)
+            => new Theme
+            {
+                Name = name,
+                OffersTransparentBackground = offersTransparency,
+
+                Background = Hex(bg),
+                HeaderBackground = Hex(bg1),
+                DialogBackground = Hex(bg1),
+                CodeBlockBackground = Hex(bg1),
+                PromptBackground = Hex(bg),
+                ToastBackground = Hex(sel),
+                StatusLineBackground = Hex(bg1),
+                KeyHintsBackground = Hex(bg2),
+
+                Text = Hex(fg),
+                TextDim = Hex(dim),
+                TextBright = Hex(fg),
+                PromptText = Hex(fg),
+
+                Primary = Hex(accent),
+                Secondary = Hex(yellow),
+                Accent = Hex(accent),
+
+                Success = Hex(green),
+                Warning = Hex(yellow),
+                Error = Hex(red),
+                Info = Hex(blue),
+
+                Heading = Hex(accent),
+                Code = Hex(cyan),
+                Ghost = Hex(dim),
+                Border = Hex(bg2),
+                Separator = Hex(bg2),
+                KeyHighlight = Hex(yellow),
+
+                HeaderTitle = Hex(accent),
+                HeaderPath = Hex(blue),
+                HeaderGitInfo = Hex(green),
+                HeaderDelimiter = Hex(dim),
+
+                SeparatorBase = Hex(dim),
+                SeparatorAccent = Hex(accent),
+                SeparatorToken = Hex(green),
+
+                Metadata = Hex(blue),
+
+                UserLabel = Hex(green),
+                UserText = Hex(fg),
+
+                ToolName = Hex(accent),
+                ToolRunning = Hex(blue),
+                ToolResult = Hex(green),
+            };
+
+        /// <summary>
+        /// Popular vim/terminal/TUI color schemes, ported to the application palette.
+        /// Light-background themes opt out of the transparent-background option.
+        /// </summary>
+        private static readonly Theme[] Popular =
+        {
+            //          name                bg        bg1       bg2       sel       fg        dim       accent    red       green     yellow    blue      magenta   cyan
+            FromPalette("gruvbox-dark",      "282828", "3c3836", "504945", "665c54", "ebdbb2", "928374", "fe8019", "fb4934", "b8bb26", "fabd2f", "83a598", "d3869b", "8ec07c"),
+            FromPalette("gruvbox-light",     "fbf1c7", "ebdbb2", "d5c4a1", "bdae93", "3c3836", "7c6f64", "af3a03", "9d0006", "79740e", "b57614", "076678", "8f3f71", "427b58", offersTransparency: false),
+            FromPalette("solarized-dark",    "002b36", "073642", "586e75", "094f5e", "839496", "586e75", "268bd2", "dc322f", "859900", "b58900", "268bd2", "d33682", "2aa198"),
+            FromPalette("solarized-light",   "fdf6e3", "eee8d5", "93a1a1", "d9d2bf", "657b83", "93a1a1", "268bd2", "dc322f", "859900", "b58900", "268bd2", "d33682", "2aa198", offersTransparency: false),
+            FromPalette("dracula",           "282a36", "343746", "44475a", "44475a", "f8f8f2", "6272a4", "bd93f9", "ff5555", "50fa7b", "f1fa8c", "8be9fd", "ff79c6", "8be9fd"),
+            FromPalette("nord",              "2e3440", "3b4252", "434c5e", "4c566a", "d8dee9", "616e88", "88c0d0", "bf616a", "a3be8c", "ebcb8b", "81a1c1", "b48ead", "8fbcbb"),
+            FromPalette("monokai",           "272822", "3e3d32", "49483e", "49483e", "f8f8f2", "75715e", "f92672", "f92672", "a6e22e", "e6db74", "66d9ef", "ae81ff", "66d9ef"),
+            FromPalette("one-dark",          "282c34", "2c313c", "3b4048", "3e4451", "abb2bf", "5c6370", "61afef", "e06c75", "98c379", "e5c07b", "61afef", "c678dd", "56b6c2"),
+            FromPalette("one-light",         "fafafa", "f0f0f0", "e5e5e6", "dbdbdc", "383a42", "a0a1a7", "4078f2", "e45649", "50a14f", "c18401", "4078f2", "a626a4", "0184bc", offersTransparency: false),
+            FromPalette("tokyo-night",       "1a1b26", "1f2335", "292e42", "33467c", "c0caf5", "565f89", "7aa2f7", "f7768e", "9ece6a", "e0af68", "7aa2f7", "bb9af7", "7dcfff"),
+            FromPalette("tokyo-night-storm", "24283b", "1f2335", "292e42", "2e3c64", "c0caf5", "565f89", "7aa2f7", "f7768e", "9ece6a", "e0af68", "7aa2f7", "bb9af7", "7dcfff"),
+            FromPalette("tokyo-night-day",   "e1e2e7", "d5d6db", "c4c8da", "b7c1e3", "343b58", "848cb5", "2e7de9", "f52a65", "587539", "8c6c3e", "2e7de9", "9854f1", "007197", offersTransparency: false),
+            FromPalette("catppuccin-mocha",  "1e1e2e", "313244", "45475a", "585b70", "cdd6f4", "6c7086", "cba6f7", "f38ba8", "a6e3a1", "f9e2af", "89b4fa", "cba6f7", "94e2d5"),
+            FromPalette("catppuccin-macchiato", "24273a", "363a4f", "494d64", "5b6078", "cad3f5", "6e738d", "c6a0f6", "ed8796", "a6da95", "eed49f", "8aadf4", "c6a0f6", "8bd5ca"),
+            FromPalette("catppuccin-frappe", "303446", "414559", "51576d", "626880", "c6d0f5", "737994", "ca9ee6", "e78284", "a6d189", "e5c890", "8caaee", "ca9ee6", "81c8be"),
+            FromPalette("catppuccin-latte",  "eff1f5", "e6e9ef", "dce0e8", "bcc0cc", "4c4f69", "8c8fa1", "1e66f5", "d20f39", "40a02b", "df8e1d", "1e66f5", "8839ef", "179299", offersTransparency: false),
+            FromPalette("tomorrow-night",    "1d1f21", "282a2e", "373b41", "373b41", "c5c8c6", "969896", "81a2be", "cc6666", "b5bd68", "f0c674", "81a2be", "b294bb", "8abeb7"),
+            FromPalette("material",          "263238", "2e3c43", "314549", "425b67", "eeffff", "546e7a", "82aaff", "f07178", "c3e88d", "ffcb6b", "82aaff", "c792ea", "89ddff"),
+            FromPalette("palenight",         "292d3e", "32374d", "444267", "444267", "a6accd", "676e95", "c792ea", "f07178", "c3e88d", "ffcb6b", "82aaff", "c792ea", "89ddff"),
+            FromPalette("everforest-dark",   "2d353b", "343f44", "3d484d", "475258", "d3c6aa", "859289", "a7c080", "e67e80", "a7c080", "dbbc7f", "7fbbb3", "d699b6", "83c092"),
+            FromPalette("everforest-light",  "fdf6e3", "f4f0d9", "efebd4", "e6e2cc", "5c6a72", "939f91", "8da101", "f85552", "8da101", "dfa000", "3a94c5", "df69ba", "35a77c", offersTransparency: false),
+            FromPalette("rose-pine",         "191724", "1f1d2e", "26233a", "403d52", "e0def4", "908caa", "c4a7e7", "eb6f92", "31748f", "f6c177", "9ccfd8", "c4a7e7", "9ccfd8"),
+            FromPalette("rose-pine-moon",    "232136", "2a273f", "393552", "44415a", "e0def4", "908caa", "c4a7e7", "eb6f92", "3e8fb0", "f6c177", "9ccfd8", "c4a7e7", "9ccfd8"),
+            FromPalette("rose-pine-dawn",    "faf4ed", "fffaf3", "f2e9e1", "dfdad9", "575279", "9893a5", "907aa9", "b4637a", "286983", "ea9d34", "56949f", "907aa9", "56949f", offersTransparency: false),
+            FromPalette("kanagawa",          "1f1f28", "2a2a37", "363646", "2d4f67", "dcd7ba", "727169", "7e9cd8", "c34043", "76946a", "dca561", "7e9cd8", "957fb8", "7aa89f"),
+            FromPalette("ayu-dark",          "0a0e14", "0d1016", "1c212b", "1d2433", "b3b1ad", "5c6773", "e6b450", "f07178", "c2d94c", "ffb454", "59c2ff", "d2a6ff", "95e6cb"),
+            FromPalette("ayu-mirage",        "1f2430", "232834", "2d3340", "33415e", "cccac2", "5c6773", "ffcc66", "f28779", "bae67e", "ffd580", "73d0ff", "d4bfff", "95e6cb"),
+            FromPalette("ayu-light",         "fafafa", "f3f4f5", "e7e8e9", "d1e4f4", "5c6166", "abb0b6", "fa8d3e", "f07171", "86b300", "f2ae49", "399ee6", "a37acc", "4cbf99", offersTransparency: false),
+            FromPalette("zenburn",           "3f3f3f", "4f4f4f", "6f6f6f", "5f5f5f", "dcdccc", "7f9f7f", "f0dfaf", "cc9393", "7f9f7f", "f0dfaf", "8cd0d3", "dc8cc3", "93e0e3"),
+            FromPalette("night-owl",         "011627", "0b2942", "1d3b53", "1d3b53", "d6deeb", "637777", "82aaff", "ef5350", "addb67", "ecc48d", "82aaff", "c792ea", "7fdbca"),
+            FromPalette("oceanic-next",      "1b2b34", "22313a", "343d46", "4f5b66", "cdd3de", "65737e", "6699cc", "ec5f67", "99c794", "fac863", "6699cc", "c594c5", "5fb3b3"),
+            FromPalette("cobalt2",           "193549", "1f4662", "15232d", "0d3a58", "ffffff", "8aa0ad", "ffc600", "ff628c", "3ad900", "ffc600", "0088ff", "fb94ff", "80fcff"),
+        };
+
         /// <summary>
         /// Registry of all predefined themes, keyed by their lower-case name.
         /// </summary>
-        private static readonly Dictionary<string, Theme> Registry =
-            new(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, Theme> Registry = BuildRegistry();
+
+        private static Dictionary<string, Theme> BuildRegistry()
+        {
+            var map = new Dictionary<string, Theme>(StringComparer.OrdinalIgnoreCase)
             {
                 [Dark.Name] = Dark,
                 [Light.Name] = Light,
             };
+            foreach (var theme in Popular)
+            {
+                map[theme.Name] = theme;
+            }
+            return map;
+        }
 
         /// <summary>
         /// The names of all available predefined themes, in a stable order.
         /// </summary>
         public static IReadOnlyList<string> AvailableThemes { get; } =
-            new[] { Dark.Name, Light.Name };
+            new[] { Dark.Name, Light.Name }.Concat(Popular.Select(t => t.Name)).ToArray();
 
         /// <summary>
         /// Look up a predefined theme by name (case-insensitive).
@@ -169,6 +322,21 @@ namespace Andy.Cli.Themes
             if (string.IsNullOrWhiteSpace(name))
                 return null;
             return Registry.TryGetValue(name.Trim(), out var theme) ? theme : null;
+        }
+
+        /// <summary>
+        /// Resolve a theme by name and apply the transparent-background preference.
+        /// Transparency is only applied when the theme offers it. Returns null when
+        /// the name does not match a predefined theme.
+        /// </summary>
+        public static Theme? Resolve(string? name, bool transparentBackground)
+        {
+            var theme = GetByName(name);
+            if (theme == null)
+                return null;
+            return transparentBackground && theme.OffersTransparentBackground
+                ? theme.WithTransparentBackground()
+                : theme;
         }
 
         /// <summary>

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Andy.Llm" Version="2026.5.29-rc.31" />
+    <PackageReference Include="Andy.Llm" Version="2026.6.7-rc.38" />
     <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.24" />
-    <PackageReference Include="Andy.Model" Version="2025.10.29-rc.5" />
+    <PackageReference Include="Andy.Model" Version="2026.5.31-rc.8" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="JsonSchema.Net" Version="9.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />

--- a/tests/Andy.Cli.Tests/AssemblyInfo.cs
+++ b/tests/Andy.Cli.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Several tests assert against the global, mutable Andy.Cli.Themes.Theme.Current
+// (theme switching, prompt/feed rendering colors). Running test classes in parallel
+// lets one class change the active theme while another renders, producing flaky
+// color assertions. Serialize the assembly so theme state is deterministic.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Andy.Cli.Tests/Themes/PopularThemesTests.cs
+++ b/tests/Andy.Cli.Tests/Themes/PopularThemesTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Andy.Cli.Commands;
+using Andy.Cli.Services;
+using Andy.Cli.Themes;
+using Xunit;
+
+namespace Andy.Cli.Tests.Themes;
+
+public class PopularThemesTests
+{
+    private static string TempPath() =>
+        Path.Combine(Path.GetTempPath(), "andy-theme-test-" + Guid.NewGuid().ToString("N"), "theme-memory.json");
+
+    // ----- New themes are registered -----
+
+    [Theory]
+    [InlineData("dracula")]
+    [InlineData("nord")]
+    [InlineData("gruvbox-dark")]
+    [InlineData("catppuccin-mocha")]
+    [InlineData("tokyo-night")]
+    [InlineData("solarized-dark")]
+    public void GetByName_FindsPopularThemes(string name)
+    {
+        var theme = Theme.GetByName(name);
+        Assert.NotNull(theme);
+        Assert.Equal(name, theme!.Name);
+    }
+
+    [Fact]
+    public void AvailableThemes_IncludesBuiltinsAndPopular()
+    {
+        Assert.Contains("dark", Theme.AvailableThemes);
+        Assert.Contains("light", Theme.AvailableThemes);
+        Assert.Contains("dracula", Theme.AvailableThemes);
+        // Built-ins (2) plus the 32 popular ports.
+        Assert.Equal(34, Theme.AvailableThemes.Count);
+    }
+
+    [Fact]
+    public void AvailableThemes_NamesAreUnique()
+    {
+        var names = Theme.AvailableThemes.ToList();
+        Assert.Equal(names.Count, names.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void DraculaPalette_MatchesCanonicalColors()
+    {
+        var d = Theme.GetByName("dracula")!;
+        Assert.Equal(new Andy.Tui.DisplayList.Rgb24(0x28, 0x2a, 0x36), d.Background);
+        Assert.Equal(new Andy.Tui.DisplayList.Rgb24(0xf8, 0xf8, 0xf2), d.Text);
+        Assert.Equal(new Andy.Tui.DisplayList.Rgb24(0xff, 0x55, 0x55), d.Error);
+    }
+
+    // ----- Transparent-background option ("the check") -----
+
+    [Fact]
+    public void DarkThemes_OfferTransparency_LightThemesDoNot()
+    {
+        Assert.True(Theme.GetByName("dracula")!.OffersTransparentBackground);
+        Assert.True(Theme.GetByName("gruvbox-dark")!.OffersTransparentBackground);
+        Assert.False(Theme.GetByName("gruvbox-light")!.OffersTransparentBackground);
+        Assert.False(Theme.GetByName("catppuccin-latte")!.OffersTransparentBackground);
+    }
+
+    [Fact]
+    public void WithTransparentBackground_NullsMainSurfaces_KeepsChrome()
+    {
+        var solid = Theme.GetByName("dracula")!;
+        Assert.False(solid.HasTransparentBackground);
+
+        var transparent = solid.WithTransparentBackground();
+        Assert.True(transparent.HasTransparentBackground);
+        Assert.Null(transparent.Background);
+        Assert.Null(transparent.HeaderBackground);
+        Assert.Null(transparent.DialogBackground);
+        Assert.Null(transparent.PromptBackground);
+        // Chrome keeps a shade for legibility.
+        Assert.Equal(solid.StatusLineBackground, transparent.StatusLineBackground);
+        // Original instance is untouched.
+        Assert.False(solid.HasTransparentBackground);
+    }
+
+    [Fact]
+    public void Resolve_AppliesTransparency_OnlyWhenOffered()
+    {
+        Assert.True(Theme.Resolve("dracula", transparentBackground: true)!.HasTransparentBackground);
+        Assert.False(Theme.Resolve("dracula", transparentBackground: false)!.HasTransparentBackground);
+        // Light theme opts out: stays solid even when requested.
+        Assert.False(Theme.Resolve("gruvbox-light", transparentBackground: true)!.HasTransparentBackground);
+        Assert.Null(Theme.Resolve("does-not-exist", true));
+    }
+
+    // ----- Command: switching and toggling -----
+
+    [Fact]
+    public async Task Command_SwitchToPopularTheme_SetsCurrentAndPersists()
+    {
+        var original = Theme.Current;
+        var path = TempPath();
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            var command = new ThemeCommand(service);
+
+            var result = await command.ExecuteAsync(new[] { "nord" });
+
+            Assert.True(result.Success);
+            Assert.Equal("nord", Theme.Current.Name);
+            Assert.Equal("nord", service.LoadTheme());
+        }
+        finally
+        {
+            Theme.Current = original;
+            Directory.Delete(Path.GetDirectoryName(path)!, true);
+        }
+    }
+
+    [Fact]
+    public async Task Command_TransparentOn_TogglesAndPersists()
+    {
+        var original = Theme.Current;
+        var path = TempPath();
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            var command = new ThemeCommand(service);
+
+            await command.ExecuteAsync(new[] { "dracula" });
+            Assert.False(Theme.Current.HasTransparentBackground);
+
+            var result = await command.ExecuteAsync(new[] { "transparent", "on" });
+
+            Assert.True(result.Success);
+            Assert.True(Theme.Current.HasTransparentBackground);
+            Assert.True(service.LoadTransparentBackground());
+            Assert.Equal("dracula", service.LoadTheme());
+
+            // And it persists across a fresh switch back to the same base theme.
+            await command.ExecuteAsync(new[] { "dracula" });
+            Assert.True(Theme.Current.HasTransparentBackground);
+        }
+        finally
+        {
+            Theme.Current = original;
+            Directory.Delete(Path.GetDirectoryName(path)!, true);
+        }
+    }
+
+    [Fact]
+    public async Task Command_TransparentOff_RestoresSolidBackground()
+    {
+        var original = Theme.Current;
+        var path = TempPath();
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            var command = new ThemeCommand(service);
+
+            await command.ExecuteAsync(new[] { "nord", });
+            await command.ExecuteAsync(new[] { "transparent", "on" });
+            Assert.True(Theme.Current.HasTransparentBackground);
+
+            var result = await command.ExecuteAsync(new[] { "transparent", "off" });
+
+            Assert.True(result.Success);
+            Assert.False(Theme.Current.HasTransparentBackground);
+            Assert.False(service.LoadTransparentBackground());
+        }
+        finally
+        {
+            Theme.Current = original;
+            Directory.Delete(Path.GetDirectoryName(path)!, true);
+        }
+    }
+
+    [Fact]
+    public async Task Command_Transparent_OnThemeThatDoesNotOffer_Fails()
+    {
+        var original = Theme.Current;
+        var path = TempPath();
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            var command = new ThemeCommand(service);
+
+            await command.ExecuteAsync(new[] { "gruvbox-light" });
+            var result = await command.ExecuteAsync(new[] { "transparent", "on" });
+
+            Assert.False(result.Success);
+            Assert.Contains("does not offer", result.Message);
+        }
+        finally
+        {
+            Theme.Current = original;
+            Directory.Delete(Path.GetDirectoryName(path)!, true);
+        }
+    }
+
+    [Fact]
+    public async Task Command_List_ShowsTransparencyCheck()
+    {
+        var original = Theme.Current;
+        var path = TempPath();
+        try
+        {
+            var service = new ThemeMemoryService(path);
+            var command = new ThemeCommand(service);
+            await command.ExecuteAsync(new[] { "dracula" });
+            await command.ExecuteAsync(new[] { "transparent", "on" });
+
+            var result = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.True(result.Success);
+            Assert.Contains("Transparent background: [x] on", result.Message);
+            Assert.Contains("[offers transparent bg]", result.Message);
+        }
+        finally
+        {
+            Theme.Current = original;
+            Directory.Delete(Path.GetDirectoryName(path)!, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Extends the UI theme system and makes theme switching visibly apply at runtime.

- **32 popular themes** (Gruvbox, Solarized, Dracula, Nord, Monokai, One, Tokyo Night, Catppuccin, Material, Palenight, Everforest, Rosé Pine, Kanagawa, Ayu, Zenburn, Night Owl, Oceanic Next, Cobalt2) via a `FromPalette` factory mapping a core palette onto the app's semantic colors. 34 themes total.
- **Transparent-background option ("the check")**: each theme declares `OffersTransparentBackground` (dark themes opt in, light themes opt out). `/theme` lists which themes offer it and shows a `[x]`/`[ ]` check for the active theme; new `/theme transparent on|off` toggles it; the preference persists and re-applies at startup.
- **Fix: `/theme` now visibly recolors the screen.** The main-surface `Append` helper stripped all backgrounds, so opaque themes rendered transparent. Opaque themes now paint a full-surface background; transparent themes and the toggle are unchanged.
- Align `Andy.Llm`/`Andy.Model` to rc.38 across app + test projects so the solution builds consistently.

## Tests
Theme resolution, the offers-transparency flag, the toggle + persistence, and the list output. Full suite: 403 passed, 1 skipped. Test assembly serialized because `Theme.Current` is global mutable state shared with rendering tests.