### PR TITLE
Consume Andy.Tui theme library; fix browser-opening and flaky theme tests

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Andy.Model" Version="2026.5.31-rc.8" />
     <PackageReference Include="Andy.Permissions" Version="2026.6.4-rc.6" />
     <PackageReference Include="Andy.Tools" Version="2026.6.4-rc.24" />
-    <PackageReference Include="Andy.Tui" Version="2026.5.29-rc.43" />
+    <PackageReference Include="Andy.Tui" Version="2026.6.7-rc.50" />
     <PackageReference Include="JsonRepairSharp" Version="1.2.3" />
     <PackageReference Include="JsonSchema.Net" Version="9.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />

--- a/src/Andy.Cli/Themes/Theme.cs
+++ b/src/Andy.Cli/Themes/Theme.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using DL = Andy.Tui.DisplayList;
+using TS = Andy.Tui.Style;
 
 namespace Andy.Cli.Themes
 {
@@ -175,118 +176,80 @@ namespace Andy.Cli.Themes
             ToolResult = new DL.Rgb24(90, 90, 90),
         };
 
-        private static DL.Rgb24 Hex(string hex)
+        // Map an Andy.Tui token-based theme onto this app's richer color model. The
+        // palette data lives in the Andy.Tui library (Andy.Tui.Style.PopularThemes);
+        // this only maps the library's semantic tokens onto the application's roles,
+        // so there is a single source of truth for the palettes.
+        private static Theme FromLibrary(TS.Theme lib)
         {
-            int o = hex.Length > 0 && hex[0] == '#' ? 1 : 0;
-            byte r = Convert.ToByte(hex.Substring(o, 2), 16);
-            byte g = Convert.ToByte(hex.Substring(o + 2, 2), 16);
-            byte b = Convert.ToByte(hex.Substring(o + 4, 2), 16);
-            return new DL.Rgb24(r, g, b);
+            DL.Rgb24 C(TS.ThemeToken token) => lib.GetRgb(token, default);
+            return new Theme
+            {
+                Name = lib.Name,
+                // Dark-background themes offer the transparent-background option;
+                // light ones do not (dark text would be unreadable on a dark terminal).
+                OffersTransparentBackground = IsDark(C(TS.ThemeToken.Background)),
+
+                Background = C(TS.ThemeToken.Background),
+                HeaderBackground = C(TS.ThemeToken.Surface),
+                DialogBackground = C(TS.ThemeToken.Surface),
+                CodeBlockBackground = C(TS.ThemeToken.Surface),
+                PromptBackground = C(TS.ThemeToken.Background),
+                ToastBackground = C(TS.ThemeToken.SurfaceSelected),
+                StatusLineBackground = C(TS.ThemeToken.Surface),
+                KeyHintsBackground = C(TS.ThemeToken.SurfaceHover),
+
+                Text = C(TS.ThemeToken.Foreground),
+                TextDim = C(TS.ThemeToken.ForegroundMuted),
+                TextBright = C(TS.ThemeToken.Foreground),
+                PromptText = C(TS.ThemeToken.Foreground),
+
+                Primary = C(TS.ThemeToken.Accent),
+                Secondary = C(TS.ThemeToken.Warning),
+                Accent = C(TS.ThemeToken.Accent),
+
+                Success = C(TS.ThemeToken.Success),
+                Warning = C(TS.ThemeToken.Warning),
+                Error = C(TS.ThemeToken.Error),
+                Info = C(TS.ThemeToken.Info),
+
+                Heading = C(TS.ThemeToken.Accent),
+                Code = C(TS.ThemeToken.SyntaxPreproc),
+                Ghost = C(TS.ThemeToken.ForegroundMuted),
+                Border = C(TS.ThemeToken.Border),
+                Separator = C(TS.ThemeToken.Border),
+                KeyHighlight = C(TS.ThemeToken.Warning),
+
+                HeaderTitle = C(TS.ThemeToken.Accent),
+                HeaderPath = C(TS.ThemeToken.Info),
+                HeaderGitInfo = C(TS.ThemeToken.Success),
+                HeaderDelimiter = C(TS.ThemeToken.ForegroundMuted),
+
+                SeparatorBase = C(TS.ThemeToken.ForegroundMuted),
+                SeparatorAccent = C(TS.ThemeToken.Accent),
+                SeparatorToken = C(TS.ThemeToken.Success),
+
+                Metadata = C(TS.ThemeToken.Info),
+
+                UserLabel = C(TS.ThemeToken.Success),
+                UserText = C(TS.ThemeToken.Foreground),
+
+                ToolName = C(TS.ThemeToken.Accent),
+                ToolRunning = C(TS.ThemeToken.Info),
+                ToolResult = C(TS.ThemeToken.Success),
+            };
         }
 
-        /// <summary>
-        /// Build a theme from a compact core palette (popular vim/terminal schemes).
-        /// The core colors are mapped to the application's semantic roles consistently
-        /// across all ported themes.
-        /// </summary>
-        private static Theme FromPalette(string name,
-            string bg, string bg1, string bg2, string sel, string fg, string dim, string accent,
-            string red, string green, string yellow, string blue, string magenta, string cyan,
-            bool offersTransparency = true)
-            => new Theme
-            {
-                Name = name,
-                OffersTransparentBackground = offersTransparency,
-
-                Background = Hex(bg),
-                HeaderBackground = Hex(bg1),
-                DialogBackground = Hex(bg1),
-                CodeBlockBackground = Hex(bg1),
-                PromptBackground = Hex(bg),
-                ToastBackground = Hex(sel),
-                StatusLineBackground = Hex(bg1),
-                KeyHintsBackground = Hex(bg2),
-
-                Text = Hex(fg),
-                TextDim = Hex(dim),
-                TextBright = Hex(fg),
-                PromptText = Hex(fg),
-
-                Primary = Hex(accent),
-                Secondary = Hex(yellow),
-                Accent = Hex(accent),
-
-                Success = Hex(green),
-                Warning = Hex(yellow),
-                Error = Hex(red),
-                Info = Hex(blue),
-
-                Heading = Hex(accent),
-                Code = Hex(cyan),
-                Ghost = Hex(dim),
-                Border = Hex(bg2),
-                Separator = Hex(bg2),
-                KeyHighlight = Hex(yellow),
-
-                HeaderTitle = Hex(accent),
-                HeaderPath = Hex(blue),
-                HeaderGitInfo = Hex(green),
-                HeaderDelimiter = Hex(dim),
-
-                SeparatorBase = Hex(dim),
-                SeparatorAccent = Hex(accent),
-                SeparatorToken = Hex(green),
-
-                Metadata = Hex(blue),
-
-                UserLabel = Hex(green),
-                UserText = Hex(fg),
-
-                ToolName = Hex(accent),
-                ToolRunning = Hex(blue),
-                ToolResult = Hex(green),
-            };
+        // Perceived luminance below the midpoint => treat as a dark background.
+        private static bool IsDark(DL.Rgb24 c)
+            => (0.299 * c.R + 0.587 * c.G + 0.114 * c.B) / 255.0 < 0.5;
 
         /// <summary>
-        /// Popular vim/terminal/TUI color schemes, ported to the application palette.
-        /// Light-background themes opt out of the transparent-background option.
+        /// Popular vim/terminal/TUI color schemes, sourced from the Andy.Tui theme
+        /// library and mapped onto this application's palette.
         /// </summary>
         private static readonly Theme[] Popular =
-        {
-            //          name                bg        bg1       bg2       sel       fg        dim       accent    red       green     yellow    blue      magenta   cyan
-            FromPalette("gruvbox-dark",      "282828", "3c3836", "504945", "665c54", "ebdbb2", "928374", "fe8019", "fb4934", "b8bb26", "fabd2f", "83a598", "d3869b", "8ec07c"),
-            FromPalette("gruvbox-light",     "fbf1c7", "ebdbb2", "d5c4a1", "bdae93", "3c3836", "7c6f64", "af3a03", "9d0006", "79740e", "b57614", "076678", "8f3f71", "427b58", offersTransparency: false),
-            FromPalette("solarized-dark",    "002b36", "073642", "586e75", "094f5e", "839496", "586e75", "268bd2", "dc322f", "859900", "b58900", "268bd2", "d33682", "2aa198"),
-            FromPalette("solarized-light",   "fdf6e3", "eee8d5", "93a1a1", "d9d2bf", "657b83", "93a1a1", "268bd2", "dc322f", "859900", "b58900", "268bd2", "d33682", "2aa198", offersTransparency: false),
-            FromPalette("dracula",           "282a36", "343746", "44475a", "44475a", "f8f8f2", "6272a4", "bd93f9", "ff5555", "50fa7b", "f1fa8c", "8be9fd", "ff79c6", "8be9fd"),
-            FromPalette("nord",              "2e3440", "3b4252", "434c5e", "4c566a", "d8dee9", "616e88", "88c0d0", "bf616a", "a3be8c", "ebcb8b", "81a1c1", "b48ead", "8fbcbb"),
-            FromPalette("monokai",           "272822", "3e3d32", "49483e", "49483e", "f8f8f2", "75715e", "f92672", "f92672", "a6e22e", "e6db74", "66d9ef", "ae81ff", "66d9ef"),
-            FromPalette("one-dark",          "282c34", "2c313c", "3b4048", "3e4451", "abb2bf", "5c6370", "61afef", "e06c75", "98c379", "e5c07b", "61afef", "c678dd", "56b6c2"),
-            FromPalette("one-light",         "fafafa", "f0f0f0", "e5e5e6", "dbdbdc", "383a42", "a0a1a7", "4078f2", "e45649", "50a14f", "c18401", "4078f2", "a626a4", "0184bc", offersTransparency: false),
-            FromPalette("tokyo-night",       "1a1b26", "1f2335", "292e42", "33467c", "c0caf5", "565f89", "7aa2f7", "f7768e", "9ece6a", "e0af68", "7aa2f7", "bb9af7", "7dcfff"),
-            FromPalette("tokyo-night-storm", "24283b", "1f2335", "292e42", "2e3c64", "c0caf5", "565f89", "7aa2f7", "f7768e", "9ece6a", "e0af68", "7aa2f7", "bb9af7", "7dcfff"),
-            FromPalette("tokyo-night-day",   "e1e2e7", "d5d6db", "c4c8da", "b7c1e3", "343b58", "848cb5", "2e7de9", "f52a65", "587539", "8c6c3e", "2e7de9", "9854f1", "007197", offersTransparency: false),
-            FromPalette("catppuccin-mocha",  "1e1e2e", "313244", "45475a", "585b70", "cdd6f4", "6c7086", "cba6f7", "f38ba8", "a6e3a1", "f9e2af", "89b4fa", "cba6f7", "94e2d5"),
-            FromPalette("catppuccin-macchiato", "24273a", "363a4f", "494d64", "5b6078", "cad3f5", "6e738d", "c6a0f6", "ed8796", "a6da95", "eed49f", "8aadf4", "c6a0f6", "8bd5ca"),
-            FromPalette("catppuccin-frappe", "303446", "414559", "51576d", "626880", "c6d0f5", "737994", "ca9ee6", "e78284", "a6d189", "e5c890", "8caaee", "ca9ee6", "81c8be"),
-            FromPalette("catppuccin-latte",  "eff1f5", "e6e9ef", "dce0e8", "bcc0cc", "4c4f69", "8c8fa1", "1e66f5", "d20f39", "40a02b", "df8e1d", "1e66f5", "8839ef", "179299", offersTransparency: false),
-            FromPalette("tomorrow-night",    "1d1f21", "282a2e", "373b41", "373b41", "c5c8c6", "969896", "81a2be", "cc6666", "b5bd68", "f0c674", "81a2be", "b294bb", "8abeb7"),
-            FromPalette("material",          "263238", "2e3c43", "314549", "425b67", "eeffff", "546e7a", "82aaff", "f07178", "c3e88d", "ffcb6b", "82aaff", "c792ea", "89ddff"),
-            FromPalette("palenight",         "292d3e", "32374d", "444267", "444267", "a6accd", "676e95", "c792ea", "f07178", "c3e88d", "ffcb6b", "82aaff", "c792ea", "89ddff"),
-            FromPalette("everforest-dark",   "2d353b", "343f44", "3d484d", "475258", "d3c6aa", "859289", "a7c080", "e67e80", "a7c080", "dbbc7f", "7fbbb3", "d699b6", "83c092"),
-            FromPalette("everforest-light",  "fdf6e3", "f4f0d9", "efebd4", "e6e2cc", "5c6a72", "939f91", "8da101", "f85552", "8da101", "dfa000", "3a94c5", "df69ba", "35a77c", offersTransparency: false),
-            FromPalette("rose-pine",         "191724", "1f1d2e", "26233a", "403d52", "e0def4", "908caa", "c4a7e7", "eb6f92", "31748f", "f6c177", "9ccfd8", "c4a7e7", "9ccfd8"),
-            FromPalette("rose-pine-moon",    "232136", "2a273f", "393552", "44415a", "e0def4", "908caa", "c4a7e7", "eb6f92", "3e8fb0", "f6c177", "9ccfd8", "c4a7e7", "9ccfd8"),
-            FromPalette("rose-pine-dawn",    "faf4ed", "fffaf3", "f2e9e1", "dfdad9", "575279", "9893a5", "907aa9", "b4637a", "286983", "ea9d34", "56949f", "907aa9", "56949f", offersTransparency: false),
-            FromPalette("kanagawa",          "1f1f28", "2a2a37", "363646", "2d4f67", "dcd7ba", "727169", "7e9cd8", "c34043", "76946a", "dca561", "7e9cd8", "957fb8", "7aa89f"),
-            FromPalette("ayu-dark",          "0a0e14", "0d1016", "1c212b", "1d2433", "b3b1ad", "5c6773", "e6b450", "f07178", "c2d94c", "ffb454", "59c2ff", "d2a6ff", "95e6cb"),
-            FromPalette("ayu-mirage",        "1f2430", "232834", "2d3340", "33415e", "cccac2", "5c6773", "ffcc66", "f28779", "bae67e", "ffd580", "73d0ff", "d4bfff", "95e6cb"),
-            FromPalette("ayu-light",         "fafafa", "f3f4f5", "e7e8e9", "d1e4f4", "5c6166", "abb0b6", "fa8d3e", "f07171", "86b300", "f2ae49", "399ee6", "a37acc", "4cbf99", offersTransparency: false),
-            FromPalette("zenburn",           "3f3f3f", "4f4f4f", "6f6f6f", "5f5f5f", "dcdccc", "7f9f7f", "f0dfaf", "cc9393", "7f9f7f", "f0dfaf", "8cd0d3", "dc8cc3", "93e0e3"),
-            FromPalette("night-owl",         "011627", "0b2942", "1d3b53", "1d3b53", "d6deeb", "637777", "82aaff", "ef5350", "addb67", "ecc48d", "82aaff", "c792ea", "7fdbca"),
-            FromPalette("oceanic-next",      "1b2b34", "22313a", "343d46", "4f5b66", "cdd3de", "65737e", "6699cc", "ec5f67", "99c794", "fac863", "6699cc", "c594c5", "5fb3b3"),
-            FromPalette("cobalt2",           "193549", "1f4662", "15232d", "0d3a58", "ffffff", "8aa0ad", "ffc600", "ff628c", "3ad900", "ffc600", "0088ff", "fb94ff", "80fcff"),
-        };
+            TS.PopularThemes.All.Select(FromLibrary).ToArray();
 
         /// <summary>
         /// Registry of all predefined themes, keyed by their lower-case name.

--- a/src/Andy.Cli/Widgets/PromptLine.cs
+++ b/src/Andy.Cli/Widgets/PromptLine.cs
@@ -352,9 +352,14 @@ namespace Andy.Cli.Widgets
         }
 
         /// <summary>Render the prompt within the provided rectangle.</summary>
-        public void Render(in L.Rect rect, DL.DisplayList baseDl, DL.DisplayListBuilder b)
+        /// <param name="themeOverride">
+        /// Theme to render with; defaults to <see cref="Theme.Current"/>. Passing an
+        /// explicit theme keeps rendering deterministic (e.g. in tests) regardless of
+        /// the global active theme.
+        /// </param>
+        public void Render(in L.Rect rect, DL.DisplayList baseDl, DL.DisplayListBuilder b, Theme? themeOverride = null)
         {
-            var theme = Theme.Current;
+            var theme = themeOverride ?? Theme.Current;
             int x = (int)rect.X, y = (int)rect.Y, w = (int)rect.Width, h = (int)rect.Height;
             const int promptPrefixWidth = 3; // " > " = 3 characters
             int innerW = Math.Max(0, w - 2 - promptPrefixWidth); // Account for borders + prompt prefix

--- a/tests/Andy.Cli.Tests/Integration/PermissionSessionBroadeningIntegrationTests.cs
+++ b/tests/Andy.Cli.Tests/Integration/PermissionSessionBroadeningIntegrationTests.cs
@@ -119,12 +119,14 @@ public sealed class PermissionSessionBroadeningIntegrationTests
         var exec = new UiUpdatingToolExecutor(sp.GetRequiredService<IToolExecutor>());
 
         // 'dotnet' is neutral (not on the engine's known-safe list) so the gate asks the first time.
-        var first = await exec.ExecuteAsync("execute_command", Cmd("dotnet help"), new ToolExecutionContext());
+        // 'dotnet build --help' prints local help; it does not build and does not open a browser
+        // (unlike 'dotnet help <command>', which launches the online docs in a browser).
+        var first = await exec.ExecuteAsync("execute_command", Cmd("dotnet build --help"), new ToolExecutionContext());
         Assert.True(first.IsSuccessful, first.ErrorMessage);
         Assert.Equal(1, driver.PromptCount);
 
-        // Different args, SAME command class (dotnet help): broadened session rule covers it -> no new prompt.
-        var second = await exec.ExecuteAsync("execute_command", Cmd("dotnet help build"), new ToolExecutionContext());
+        // Different args, SAME command class (dotnet build): broadened session rule covers it -> no new prompt.
+        var second = await exec.ExecuteAsync("execute_command", Cmd("dotnet build -h"), new ToolExecutionContext());
         Assert.True(second.IsSuccessful, second.ErrorMessage);
         Assert.Equal(1, driver.PromptCount);
     }

--- a/tests/Andy.Cli.Tests/Widgets/PromptLineColorTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/PromptLineColorTests.cs
@@ -26,25 +26,19 @@ public class PromptLineColorTests
 
     private static DL.DisplayList RenderWith(Theme theme, string text)
     {
-        var original = Theme.Current;
-        try
-        {
-            Theme.Current = theme;
-            var prompt = new PromptLine();
-            prompt.SetText(text);
+        // Render with an explicit theme rather than mutating the global Theme.Current,
+        // so the assertion is deterministic even if another test changes the active
+        // theme concurrently.
+        var prompt = new PromptLine();
+        prompt.SetText(text);
 
-            var baseBuilder = new DL.DisplayListBuilder();
-            var baseDl = baseBuilder.Build();
-            var builder = new DL.DisplayListBuilder();
+        var baseBuilder = new DL.DisplayListBuilder();
+        var baseDl = baseBuilder.Build();
+        var builder = new DL.DisplayListBuilder();
 
-            var rect = new L.Rect(0, 0, 40, 5);
-            prompt.Render(rect, baseDl, builder);
-            return builder.Build();
-        }
-        finally
-        {
-            Theme.Current = original;
-        }
+        var rect = new L.Rect(0, 0, 40, 5);
+        prompt.Render(rect, baseDl, builder, theme);
+        return builder.Build();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Switches the app to consume the theme palettes from the **Andy.Tui** package instead of duplicating them, and fixes two test issues.

- **Bump `Andy.Tui` to `2026.6.7-rc.50`**, which ships the new `Andy.Tui.Style` theme system.
- **Single source of truth for palettes**: the 32 popular themes are now sourced from `Andy.Tui.Style.PopularThemes`; a small `FromLibrary` mapper translates the library's semantic tokens onto the app's richer (~40-role) color model. The duplicated hex palettes are removed. Output colors are unchanged (theme tests still pass).
- **No more browser pop-ups in tests**: the permission-broadening integration test ran `dotnet help build`, which opens the online docs in a browser. Replaced with `dotnet build --help` / `-h` (local help, same command class, no browser, no actual build).
- **Fixed the intermittent `PromptLineColorTests` failure**: `PromptLine.Render` now accepts an optional theme override; the test passes its theme explicitly instead of mutating the global `Theme.Current`, so it's immune to cross-test contamination.

## Tests
Full suite: 403 passed / 1 skipped, stable across 5 consecutive runs.