### PR TITLE
Fix theme surface cohesion, LLM response background, and command palette execution

### DIFF
--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -463,7 +463,7 @@ class Program
                     Description = "Show available AI models",
                     Category = "Model",
                     Aliases = new[] { "models", "list" },
-                    Action = async args =>
+                    AsyncAction = async args =>
                     {
                         var modelListItem = await modelCommand.CreateModelListItemAsync();
                         feed.AddItem(modelListItem);
@@ -477,7 +477,7 @@ class Program
                     Aliases = new[] { "switch", "change" },
                     RequiredParams = new[] { "provider" },
                     ParameterHint = "Example: cerebras or openai gpt-4o",
-                    Action = async args =>
+                    AsyncAction = async args =>
                     {
                         if (args.Length < 1)
                         {
@@ -533,7 +533,7 @@ class Program
                     Description = "Show current model details",
                     Category = "Model",
                     Aliases = new[] { "info", "current" },
-                    Action = async args =>
+                    AsyncAction = async args =>
                     {
                         var result = await modelCommand.ExecuteAsync(new[] { "info" });
                         feed.AddMarkdownRich(result.Message);
@@ -545,7 +545,7 @@ class Program
                     Description = "Test current model",
                     Category = "Model",
                     Aliases = new[] { "test" },
-                    Action = async args =>
+                    AsyncAction = async args =>
                     {
                         var result = await modelCommand.ExecuteAsync(new[] { "test" }.Concat(args).ToArray());
                         feed.AddMarkdownRich(result.Message);
@@ -585,7 +585,7 @@ class Program
                         }
                         return Array.Empty<string>();
                     },
-                    Action = async args =>
+                    AsyncAction = async args =>
                     {
                         if (args.Length < 1)
                         {
@@ -620,7 +620,7 @@ class Program
                         }
                         return Array.Empty<string>();
                     },
-                    Action = async args =>
+                    AsyncAction = async args =>
                     {
                         if (args.Length < 1)
                         {
@@ -672,7 +672,7 @@ class Program
                     RequiredParams = new[] { "theme" },
                     ParameterHint = "Example: dark or light",
                     GetAvailableOptions = () => Andy.Cli.Themes.Theme.AvailableThemes.ToArray(),
-                    Action = async args =>
+                    AsyncAction = async args =>
                     {
                         var result = await themeCommand.ExecuteAsync(args);
                         feed.AddMarkdownRich(result.Message);

--- a/src/Andy.Cli/Themes/Theme.cs
+++ b/src/Andy.Cli/Themes/Theme.cs
@@ -190,14 +190,17 @@ namespace Andy.Cli.Themes
                 // light ones do not (dark text would be unreadable on a dark terminal).
                 OffersTransparentBackground = IsDark(C(TS.ThemeToken.Background)),
 
+                // Header, prompt and footer share the body background so the surface
+                // reads as one cohesive color; dialogs/code/toasts intentionally stand
+                // out with a raised surface.
                 Background = C(TS.ThemeToken.Background),
-                HeaderBackground = C(TS.ThemeToken.Surface),
+                HeaderBackground = C(TS.ThemeToken.Background),
                 DialogBackground = C(TS.ThemeToken.Surface),
                 CodeBlockBackground = C(TS.ThemeToken.Surface),
                 PromptBackground = C(TS.ThemeToken.Background),
                 ToastBackground = C(TS.ThemeToken.SurfaceSelected),
-                StatusLineBackground = C(TS.ThemeToken.Surface),
-                KeyHintsBackground = C(TS.ThemeToken.SurfaceHover),
+                StatusLineBackground = C(TS.ThemeToken.Background),
+                KeyHintsBackground = C(TS.ThemeToken.Background),
 
                 Text = C(TS.ThemeToken.Foreground),
                 TextDim = C(TS.ThemeToken.ForegroundMuted),

--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -1086,6 +1086,12 @@ namespace Andy.Cli.Widgets
             // Detect simple HTML links <a href="...">text</a> and render with Link widget
             if (TryRenderSimpleHtmlLink(slice, x, y, width, maxLines, baseDl, b)) return;
             var r = new Andy.Tui.Widgets.MarkdownRenderer();
+            // Render on the theme background (opaque themes); the renderer defaults to a
+            // black background, so without this LLM responses show up on a black block.
+            // Transparent themes leave it for the compositor to strip to the terminal bg.
+            var theme = Themes.Theme.Current;
+            if (theme.Background is { } mdBg)
+                r.SetColors(theme.Text, mdBg, theme.Accent);
             r.SetText(slice);
             r.Render(new L.Rect(x, y, width, maxLines), baseDl, b);
         }
@@ -1662,8 +1668,12 @@ namespace Andy.Cli.Widgets
                 return;
             }
 
-            // Render as simple markdown-styled text
+            // Render as simple markdown-styled text on the theme background (opaque
+            // themes); otherwise the renderer's default black background shows through.
             var renderer = new Andy.Tui.Widgets.MarkdownRenderer();
+            var theme = Themes.Theme.Current;
+            if (theme.Background is { } mdBg)
+                renderer.SetColors(theme.Text, mdBg, theme.Accent);
             renderer.SetText(_content.ToString());
             renderer.Render(new L.Rect(x, y, width, maxLines), baseDl, b);
 

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -31,10 +31,12 @@
   <ItemGroup>
     <!-- Temporarily exclude test files that need updating for new API -->
     <Compile Remove="**/*.cs" />
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="TestHelpers/TestCompatibilityShims.cs" />
     <Compile Include="VersionInfoTests.cs" />
     <Compile Include="Commands/ModelCommandTests.cs" />
     <Compile Include="Themes/ThemeSwitchingTests.cs" />
+    <Compile Include="Themes/PopularThemesTests.cs" />
     <Compile Include="Services/ProviderDetectionServiceTests.cs" />
     <Compile Include="Services/SystemPromptBuilderTests.cs" />
     <Compile Include="Services/SystemPromptsTests.cs" />
@@ -53,6 +55,8 @@
     <Compile Include="Widgets/KeyHintsBarTests.cs" />
     <!-- PromptLine color/style tests -->
     <Compile Include="Widgets/PromptLineColorTests.cs" />
+    <!-- Command palette execution tests -->
+    <Compile Include="Widgets/CommandPaletteTests.cs" />
     <!-- PromptLine soft-wrapping + cursor navigation tests -->
     <Compile Include="Widgets/PromptLineWrappingTests.cs" />
     <!-- FeedView reflow signal tests (margin residue fix) -->

--- a/tests/Andy.Cli.Tests/Widgets/CommandPaletteTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/CommandPaletteTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading.Tasks;
+using Andy.Cli.Widgets;
+using Xunit;
+
+namespace Andy.Cli.Tests.Widgets;
+
+/// <summary>
+/// Guards command-palette execution. Commands with async bodies must be registered
+/// as <see cref="CommandPalette.CommandItem.AsyncAction"/> so the palette awaits them
+/// to completion; an async lambda assigned to the synchronous
+/// <see cref="CommandPalette.CommandItem.Action"/> is fire-and-forget (async void) and
+/// its work can be lost when the palette closes — that was the "/list doesn't run" bug.
+/// </summary>
+public class CommandPaletteTests
+{
+    private static CommandPalette PaletteWith(params CommandPalette.CommandItem[] items)
+    {
+        var p = new CommandPalette();
+        p.SetCommands(items);
+        p.Open();
+        return p;
+    }
+
+    [Fact]
+    public void Query_list_SelectsTheAliasedCommand()
+    {
+        var p = PaletteWith(
+            new CommandPalette.CommandItem { Name = "List Models", Aliases = new[] { "models", "list" }, AsyncAction = _ => Task.CompletedTask },
+            new CommandPalette.CommandItem { Name = "Switch Model", Aliases = new[] { "switch" }, AsyncAction = _ => Task.CompletedTask });
+
+        p.SetQuery("list");
+
+        Assert.Equal("List Models", p.GetSelected()?.Name);
+    }
+
+    [Fact]
+    public async Task ExecuteSelected_AwaitsAsyncActionToCompletion_AndCloses()
+    {
+        bool ran = false;
+        var p = PaletteWith(new CommandPalette.CommandItem
+        {
+            Name = "List Models",
+            Aliases = new[] { "list" },
+            // Completes only after yielding; a fire-and-forget call would return before this runs.
+            AsyncAction = async _ => { await Task.Yield(); await Task.Delay(10); ran = true; }
+        });
+        p.SetQuery("list");
+
+        await p.ExecuteSelectedAsync();
+
+        Assert.True(ran, "AsyncAction should be awaited to completion before ExecuteSelectedAsync returns");
+        Assert.False(p.IsOpen, "palette should close after running a no-parameter command");
+    }
+
+    [Fact]
+    public async Task ExecuteSelected_RunsSyncAction()
+    {
+        bool ran = false;
+        var p = PaletteWith(new CommandPalette.CommandItem
+        {
+            Name = "Clear",
+            Aliases = new[] { "clear" },
+            Action = _ => ran = true
+        });
+        p.SetQuery("clear");
+
+        await p.ExecuteSelectedAsync();
+
+        Assert.True(ran);
+        Assert.False(p.IsOpen);
+    }
+
+    [Fact]
+    public async Task ExecuteSelected_WithRequiredParams_EntersParamModeInsteadOfRunning()
+    {
+        bool ran = false;
+        var p = PaletteWith(new CommandPalette.CommandItem
+        {
+            Name = "Tool Info",
+            Aliases = new[] { "info" },
+            RequiredParams = new[] { "tool" },
+            AsyncAction = _ => { ran = true; return Task.CompletedTask; }
+        });
+        p.SetQuery("info");
+
+        await p.ExecuteSelectedAsync();
+
+        Assert.True(p.IsWaitingForParams(), "a command with required params should switch to parameter input");
+        Assert.False(ran, "it should not run until parameters are confirmed");
+
+        // Confirm with a parameter -> now it runs and closes.
+        p.SetParamInput("copy_file");
+        await p.ExecuteSelectedAsync();
+        Assert.True(ran);
+        Assert.False(p.IsOpen);
+    }
+}


### PR DESCRIPTION
Fixes reported issues: LLM responses on a black block (opaque themes), footer using a different background, and `/list`-style command palette entries not running from Ctrl/Cmd+P (they were async-void fire-and-forget). Also compiles three test files that the explicit-include csproj had been silently skipping. Full suite: 424 passed / 1 skipped, stable across 4 runs.