### PR TITLE
Allow terminal text selection: mouse capture off by default, F3 to toggle

### DIFF
--- a/src/Andy.Cli/Input/MouseReporting.cs
+++ b/src/Andy.Cli/Input/MouseReporting.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Andy.Cli.Input;
+
+/// <summary>
+/// Tracks and toggles SGR mouse reporting for a terminal.
+///
+/// While mouse reporting is on the terminal forwards mouse events (clicks,
+/// drags, wheel) to the application, which suppresses the terminal emulator's
+/// native click-drag text selection. Turning it off restores native selection.
+/// The CLI only uses mouse events for wheel scrolling, which is also reachable
+/// via PageUp/PageDown, so reporting defaults to off and is opt-in.
+///
+/// The actual terminal writes are routed through an injected sink so the state
+/// machine can be unit-tested without a real TTY.
+/// </summary>
+internal sealed class MouseReporting
+{
+    // 1000 = button tracking (reports wheel as buttons 64/65); 1006 = SGR
+    // extended coordinates. Disable inverts both ('h' -> 'l').
+    internal const string EnableSeq = "\u001b[?1000h\u001b[?1006h";
+    internal const string DisableSeq = "\u001b[?1000l\u001b[?1006l";
+
+    private readonly Action<string> _write;
+    private readonly object _lock = new();
+    private bool _enabled;
+
+    public MouseReporting(Action<string> write)
+        => _write = write ?? throw new ArgumentNullException(nameof(write));
+
+    /// <summary>Current reporting state.</summary>
+    public bool Enabled
+    {
+        get { lock (_lock) return _enabled; }
+    }
+
+    /// <summary>
+    /// Set reporting on or off and return the new state. Writes the matching
+    /// escape sequence only on an actual state change; a failed write is
+    /// swallowed (best effort) but the tracked state still advances.
+    /// </summary>
+    public bool Set(bool enabled)
+    {
+        lock (_lock)
+        {
+            if (enabled == _enabled) return _enabled;
+            try { _write(enabled ? EnableSeq : DisableSeq); }
+            catch { /* ignore: best effort, terminal may be gone */ }
+            _enabled = enabled;
+            return _enabled;
+        }
+    }
+
+    /// <summary>Flip reporting and return the new state.</summary>
+    public bool Toggle()
+    {
+        lock (_lock) return Set(!_enabled);
+    }
+}

--- a/src/Andy.Cli/Input/RawTerminalInput.cs
+++ b/src/Andy.Cli/Input/RawTerminalInput.cs
@@ -12,10 +12,12 @@ namespace Andy.Cli.Input;
 /// existing keyboard handling.
 ///
 /// On start it puts the TTY into cbreak mode via <c>stty</c> (no echo, no
-/// canonical line buffering, CR left untranslated), enables SGR mouse reporting,
-/// and spins a background thread that polls fd 0 and feeds bytes through
-/// <see cref="TerminalInputParser"/>. Decoded events are queued for the main
-/// loop to drain. The original terminal settings and mouse mode are restored on
+/// canonical line buffering, CR left untranslated) and spins a background thread
+/// that polls fd 0 and feeds bytes through <see cref="TerminalInputParser"/>.
+/// Decoded events are queued for the main loop to drain. SGR mouse reporting is
+/// off by default (so the terminal's native click-drag text selection keeps
+/// working) and can be toggled at runtime via <see cref="SetMouseReporting"/>.
+/// The original terminal settings and mouse mode are restored on
 /// <see cref="Dispose"/>, process exit, and Ctrl+C.
 ///
 /// Input is read with libc <c>poll</c>/<c>read</c> on fd 0 rather than
@@ -40,20 +42,15 @@ public sealed class RawTerminalInput : IDisposable
     private readonly ConcurrentQueue<TerminalInputEvent> _queue = new();
     private readonly Thread _thread;
     private readonly string _savedStty;
-    private readonly bool _mouseEnabled;
+    private readonly MouseReporting _mouse;
     private volatile bool _stop;
     private int _restored; // 0 = not yet restored, 1 = restored (guards idempotency)
 
     private RawTerminalInput(string savedStty, bool enableMouse)
     {
         _savedStty = savedStty;
-        if (enableMouse)
-        {
-            // 1000 = button tracking (reports wheel as buttons 64/65),
-            // 1006 = SGR extended coordinates.
-            Console.Write("\u001b[?1000h\u001b[?1006h");
-            _mouseEnabled = true;
-        }
+        _mouse = new MouseReporting(Console.Write);
+        if (enableMouse) _mouse.Set(true);
 
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
         Console.CancelKeyPress += OnCancelKeyPress;
@@ -63,11 +60,30 @@ public sealed class RawTerminalInput : IDisposable
     }
 
     /// <summary>
+    /// Whether SGR mouse reporting is currently enabled. When on, the terminal
+    /// forwards mouse events to the app and native click-drag text selection is
+    /// suppressed.
+    /// </summary>
+    public bool MouseEnabled => _mouse.Enabled;
+
+    /// <summary>
+    /// Turn SGR mouse reporting on or off at runtime and return the new state.
+    /// </summary>
+    public bool SetMouseReporting(bool enabled) => _mouse.Set(enabled);
+
+    /// <summary>Flip mouse reporting and return the new state.</summary>
+    public bool ToggleMouseReporting() => _mouse.Toggle();
+
+    /// <summary>
     /// Attempt to switch the terminal into raw byte mode. Returns <c>null</c>
     /// when input is not an interactive TTY or <c>stty</c> is unavailable, in
     /// which case the caller should keep using <c>Console.ReadKey</c>.
+    ///
+    /// <paramref name="enableMouse"/> defaults to <c>false</c> so the terminal's
+    /// native click-drag text selection keeps working out of the box; callers
+    /// can opt in up front or flip it later via <see cref="SetMouseReporting"/>.
     /// </summary>
-    public static RawTerminalInput? TryStart(bool enableMouse)
+    public static RawTerminalInput? TryStart(bool enableMouse = false)
     {
         if (Console.IsInputRedirected) return null;
 
@@ -145,7 +161,9 @@ public sealed class RawTerminalInput : IDisposable
     {
         // Run at most once across Dispose / ProcessExit / Ctrl+C.
         if (Interlocked.Exchange(ref _restored, 1) != 0) return;
-        try { if (_mouseEnabled) Console.Write("\u001b[?1000l\u001b[?1006l"); } catch { /* ignore */ }
+        // Always disable mouse reporting on the way out if it was ever enabled,
+        // so the terminal is left with native click-drag selection restored.
+        SetMouseReporting(false);
         try { RunStty(_savedStty, out _); } catch { /* ignore */ }
     }
 

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -186,11 +186,12 @@ class Program
         Console.Write("[49m");
         Console.Clear();
 
-        // Switch the terminal into raw byte mode so we can receive mouse wheel
-        // events. Returns null (and we fall back to Console.ReadKey) when input
-        // is redirected or stty is unavailable. Mouse reporting is only enabled
-        // when this succeeds, since Console.ReadKey cannot decode mouse bytes.
-        var rawInput = RawTerminalInput.TryStart(enableMouse: true);
+        // Switch the terminal into raw byte mode for keyboard decoding. Returns
+        // null (and we fall back to Console.ReadKey) when input is redirected or
+        // stty is unavailable. Mouse reporting starts OFF so the terminal's
+        // native click-drag text selection keeps working; the user can toggle
+        // mouse-wheel capture on with F3 (PageUp/PageDown scroll either way).
+        var rawInput = RawTerminalInput.TryStart(enableMouse: false);
 
         try
         {
@@ -692,6 +693,7 @@ class Program
                             "- **Ctrl+]**: Toggle scroll mode (Feed ↔ Prompt History)\n" +
                             "- **Ctrl+D**: Quit application\n" +
                             "- **F2**: Toggle HUD (performance overlay)\n" +
+                            "- **F3**: Toggle mouse capture (off = native text selection; on = mouse-wheel scroll)\n" +
                             "- **ESC**: Quit application\n" +
                             "- **Page Up/Down**: Scroll chat history\n" +
                             "- **↑/↓**: Navigate multi-line text or prompt history (when in History mode)\n" +
@@ -936,6 +938,27 @@ class Program
                     }
                     if (k.Key == ConsoleKey.F2) { hud.Enabled = !hud.Enabled; return; }
 
+                    // F3 toggles mouse capture. Mouse capture is off by default
+                    // so the terminal's native click-drag text selection works;
+                    // turning it on enables mouse-wheel scrolling of the feed at
+                    // the cost of suppressing native selection. Wheel scrolling
+                    // is also available via PageUp/PageDown regardless.
+                    if (k.Key == ConsoleKey.F3)
+                    {
+                        if (rawInput == null)
+                        {
+                            toast.Show("Mouse capture unavailable (no raw terminal)", 90);
+                        }
+                        else
+                        {
+                            bool on = rawInput.ToggleMouseReporting();
+                            toast.Show(on
+                                ? "Mouse capture ON (wheel scrolls; native text selection disabled)"
+                                : "Mouse capture OFF (native text selection enabled)", 120);
+                        }
+                        return;
+                    }
+
                     // Handle Ctrl+P / Cmd+P for command palette
                     if (k.Key == ConsoleKey.P && (k.Modifiers & ConsoleModifiers.Control) != 0)
                     {
@@ -1159,6 +1182,7 @@ class Program
                                         "- **Ctrl+]**: Toggle scroll mode (Feed ↔ Prompt History)\n" +
                                         "- **Ctrl+D**: Quit application\n" +
                                         "- **F2**: Toggle HUD (performance overlay)\n" +
+                            "- **F3**: Toggle mouse capture (off = native text selection; on = mouse-wheel scroll)\n" +
                                         "- **ESC**: Quit application\n" +
                                         "- **Page Up/Down**: Scroll chat history\n" +
                                         "- **↑/↓**: Navigate multi-line text or prompt history (when in History mode)\n" +

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Widgets/CommandOutputWidthTests.cs" />
     <!-- Raw terminal input decoder tests (mouse wheel + keyboard) -->
     <Compile Include="Input/TerminalInputParserTests.cs" />
+    <!-- Mouse reporting enable/disable tests -->
+    <Compile Include="Input/MouseReportingTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
     <!-- Parallel tool execution tests -->

--- a/tests/Andy.Cli.Tests/Input/MouseReportingTests.cs
+++ b/tests/Andy.Cli.Tests/Input/MouseReportingTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using Andy.Cli.Input;
+using Xunit;
+
+namespace Andy.Cli.Tests.Input;
+
+/// <summary>
+/// Tests for <see cref="MouseReporting"/>, the SGR mouse-reporting toggle.
+///
+/// Mouse reporting suppresses the terminal's native click-drag text selection,
+/// so the CLI keeps it off by default and only writes the enable/disable escape
+/// sequences on an actual state change. These tests pin the exact init/teardown
+/// sequences and the toggle/idempotency behavior using a fake write sink.
+/// </summary>
+public class MouseReportingTests
+{
+    private static MouseReporting NewWithSink(out List<string> writes)
+    {
+        var captured = new List<string>();
+        writes = captured;
+        return new MouseReporting(captured.Add);
+    }
+
+    [Fact]
+    public void StartsDisabled_AndWritesNothing()
+    {
+        var m = NewWithSink(out var writes);
+
+        Assert.False(m.Enabled);
+        Assert.Empty(writes);
+    }
+
+    [Fact]
+    public void Enable_WritesExactEnableSequence()
+    {
+        var m = NewWithSink(out var writes);
+
+        bool now = m.Set(true);
+
+        Assert.True(now);
+        Assert.True(m.Enabled);
+        Assert.Equal(new[] { MouseReporting.EnableSeq }, writes);
+    }
+
+    [Fact]
+    public void EnableSequence_TurnsOnButtonTrackingAndSgrCoordinates()
+    {
+        // 1000h = button tracking, 1006h = SGR extended coordinates.
+        Assert.Equal("\u001b[?1000h\u001b[?1006h", MouseReporting.EnableSeq);
+    }
+
+    [Fact]
+    public void DisableSequence_IsTheInverseOfEnable()
+    {
+        // Same modes, terminated with 'l' (reset) instead of 'h' (set).
+        Assert.Equal("\u001b[?1000l\u001b[?1006l", MouseReporting.DisableSeq);
+        Assert.Equal(
+            MouseReporting.EnableSeq.Replace('h', 'l'),
+            MouseReporting.DisableSeq);
+    }
+
+    [Fact]
+    public void EnableThenDisable_WritesBothSequencesInOrder()
+    {
+        var m = NewWithSink(out var writes);
+
+        m.Set(true);
+        bool now = m.Set(false);
+
+        Assert.False(now);
+        Assert.False(m.Enabled);
+        Assert.Equal(new[] { MouseReporting.EnableSeq, MouseReporting.DisableSeq }, writes);
+    }
+
+    [Fact]
+    public void SettingSameState_IsIdempotent_NoExtraWrites()
+    {
+        var m = NewWithSink(out var writes);
+
+        m.Set(true);
+        m.Set(true); // no-op
+        Assert.Single(writes);
+
+        m.Set(false);
+        m.Set(false); // no-op
+        Assert.Equal(2, writes.Count);
+    }
+
+    [Fact]
+    public void DisableWhileAlreadyOff_WritesNothing()
+    {
+        var m = NewWithSink(out var writes);
+
+        bool now = m.Set(false);
+
+        Assert.False(now);
+        Assert.Empty(writes);
+    }
+
+    [Fact]
+    public void Toggle_FlipsStateAndEmitsMatchingSequences()
+    {
+        var m = NewWithSink(out var writes);
+
+        Assert.True(m.Toggle());  // off -> on
+        Assert.False(m.Toggle()); // on -> off
+        Assert.True(m.Toggle());  // off -> on
+
+        Assert.Equal(
+            new[] { MouseReporting.EnableSeq, MouseReporting.DisableSeq, MouseReporting.EnableSeq },
+            writes);
+    }
+
+    [Fact]
+    public void FailedWrite_DoesNotThrow_ButStillAdvancesState()
+    {
+        var m = new MouseReporting(_ => throw new System.IO.IOException("terminal gone"));
+
+        bool now = m.Set(true);
+
+        Assert.True(now);
+        Assert.True(m.Enabled);
+    }
+}


### PR DESCRIPTION
## Summary
The TUI enabled SGR mouse reporting at startup, which makes the terminal forward mouse events to the app and suppresses native click-drag text selection. Mouse events were used for exactly one thing — wheel scrolling of the feed — which is fully redundant with PageUp/PageDown.

- Mouse capture is now **off by default**, so selecting/copying text works out of the box.
- **F3** toggles mouse capture at runtime (with a confirming toast) for users who want wheel scrolling; documented in `/help`.
- Mouse reporting state extracted into a small, testable `MouseReporting` class; teardown always disables it.
- 9 tests pin the exact enable/disable escape sequences, the disable=inverse invariant, idempotency, and no-throw-on-failed-write. (Also added the test file to the explicit-include test csproj so it actually compiles.)

Full suite: 433 passed / 1 skipped.

Note: this changes default mouse behavior (wheel scroll now requires F3), so flagging for review before merge.