### PR TITLE
Theme backgrounds for response separators and model/tool list items

### DIFF
--- a/src/Andy.Cli/Widgets/ModelListItem.cs
+++ b/src/Andy.Cli/Widgets/ModelListItem.cs
@@ -70,7 +70,7 @@ namespace Andy.Cli.Widgets
         {
             if (width <= 0 || maxLines <= 0) return;
 
-            var blackBg = new DL.Rgb24(0, 0, 0);
+            DL.Rgb24? bg = Themes.Theme.Current.Background; // theme surface; null (transparent) is stripped downstream
             var greenFg = new DL.Rgb24(0, 255, 0);
             var redFg = new DL.Rgb24(255, 80, 80);
             var whiteFg = new DL.Rgb24(220, 220, 220);
@@ -85,7 +85,7 @@ namespace Andy.Cli.Widgets
             {
                 if (currentLine >= startLine && renderedLines < maxLines)
                 {
-                    b.DrawText(new DL.TextRun(x, y + renderedLines, _title, whiteFg, blackBg, DL.CellAttrFlags.Bold));
+                    b.DrawText(new DL.TextRun(x, y + renderedLines, _title, whiteFg, bg, DL.CellAttrFlags.Bold));
                     renderedLines++;
                 }
                 currentLine++;
@@ -101,7 +101,7 @@ namespace Andy.Cli.Widgets
                     // Provider header
                     if (currentLine >= startLine && renderedLines < maxLines)
                     {
-                        b.DrawText(new DL.TextRun(x, y + renderedLines, entry.Provider + ":", cyanFg, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(x, y + renderedLines, entry.Provider + ":", cyanFg, bg, DL.CellAttrFlags.None));
                         renderedLines++;
                     }
                     currentLine++;
@@ -118,19 +118,19 @@ namespace Andy.Cli.Widgets
 
                         // Render indicator
                         int pos = x;
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, indicator, whiteFg, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, indicator, whiteFg, bg, DL.CellAttrFlags.None));
                         pos += indicator.Length;
 
                         // Render colored status with brackets
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "[", whiteFg, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "[", whiteFg, bg, DL.CellAttrFlags.None));
                         pos += 1;
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, status, statusColor, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, status, statusColor, bg, DL.CellAttrFlags.None));
                         pos += status.Length;
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "] ", whiteFg, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "] ", whiteFg, bg, DL.CellAttrFlags.None));
                         pos += 2;
 
                         // Render model name and availability
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, entry.ModelName + availability, whiteFg, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, entry.ModelName + availability, whiteFg, bg, DL.CellAttrFlags.None));
 
                         renderedLines++;
                     }
@@ -141,7 +141,7 @@ namespace Andy.Cli.Widgets
                     {
                         if (currentLine >= startLine && renderedLines < maxLines)
                         {
-                            b.DrawText(new DL.TextRun(x + 5, y + renderedLines, entry.Description, grayFg, blackBg, DL.CellAttrFlags.None));
+                            b.DrawText(new DL.TextRun(x + 5, y + renderedLines, entry.Description, grayFg, bg, DL.CellAttrFlags.None));
                             renderedLines++;
                         }
                         currentLine++;
@@ -159,22 +159,22 @@ namespace Andy.Cli.Widgets
                             if (parts.Length == 2)
                             {
                                 int pos = x;
-                                b.DrawText(new DL.TextRun(pos, y + renderedLines, parts[0], whiteFg, blackBg, DL.CellAttrFlags.None));
+                                b.DrawText(new DL.TextRun(pos, y + renderedLines, parts[0], whiteFg, bg, DL.CellAttrFlags.None));
                                 pos += parts[0].Length;
-                                b.DrawText(new DL.TextRun(pos, y + renderedLines, "[", whiteFg, blackBg, DL.CellAttrFlags.None));
+                                b.DrawText(new DL.TextRun(pos, y + renderedLines, "[", whiteFg, bg, DL.CellAttrFlags.None));
                                 pos += 1;
-                                b.DrawText(new DL.TextRun(pos, y + renderedLines, "SET", greenFg, blackBg, DL.CellAttrFlags.None));
+                                b.DrawText(new DL.TextRun(pos, y + renderedLines, "SET", greenFg, bg, DL.CellAttrFlags.None));
                                 pos += 3;
-                                b.DrawText(new DL.TextRun(pos, y + renderedLines, "]", whiteFg, blackBg, DL.CellAttrFlags.None));
+                                b.DrawText(new DL.TextRun(pos, y + renderedLines, "]", whiteFg, bg, DL.CellAttrFlags.None));
                             }
                             else
                             {
-                                b.DrawText(new DL.TextRun(x, y + renderedLines, entry.Description, whiteFg, blackBg, DL.CellAttrFlags.None));
+                                b.DrawText(new DL.TextRun(x, y + renderedLines, entry.Description, whiteFg, bg, DL.CellAttrFlags.None));
                             }
                         }
                         else
                         {
-                            b.DrawText(new DL.TextRun(x, y + renderedLines, entry.Description, whiteFg, blackBg, DL.CellAttrFlags.None));
+                            b.DrawText(new DL.TextRun(x, y + renderedLines, entry.Description, whiteFg, bg, DL.CellAttrFlags.None));
                         }
                         renderedLines++;
                     }

--- a/src/Andy.Cli/Widgets/ResponseSeparator.cs
+++ b/src/Andy.Cli/Widgets/ResponseSeparator.cs
@@ -41,6 +41,8 @@ namespace Andy.Cli.Widgets
             // Center the pattern
             int patternLength = fullPattern.Length;
             int startX = x + Math.Max(0, (width - patternLength) / 2);
+            // Use the theme background so the separator doesn't sit on a black block under opaque themes.
+            var bg = Themes.Theme.Current.Background;
 
             // Render the main pattern
             for (int i = 0; i < _pattern.Length && startX + i < x + width; i++)
@@ -49,7 +51,7 @@ namespace Andy.Cli.Widgets
                 var color = (ch == '◆') ? accentColor : baseColor;
                 var attrs = (ch == '◆') ? DL.CellAttrFlags.Bold : DL.CellAttrFlags.None;
 
-                b.DrawText(new DL.TextRun(startX + i, y, ch.ToString(), color, new DL.Rgb24(0, 0, 0), attrs));
+                b.DrawText(new DL.TextRun(startX + i, y, ch.ToString(), color, bg, attrs));
             }
 
             // Render token information
@@ -59,7 +61,7 @@ namespace Andy.Cli.Widgets
                 for (int i = 0; i < tokenInfo.Length && tokenStartX + i < x + width; i++)
                 {
                     char ch = tokenInfo[i];
-                    b.DrawText(new DL.TextRun(tokenStartX + i, y, ch.ToString(), tokenColor, new DL.Rgb24(0, 0, 0), DL.CellAttrFlags.None));
+                    b.DrawText(new DL.TextRun(tokenStartX + i, y, ch.ToString(), tokenColor, bg, DL.CellAttrFlags.None));
                 }
             }
         }

--- a/src/Andy.Cli/Widgets/ToolListItem.cs
+++ b/src/Andy.Cli/Widgets/ToolListItem.cs
@@ -68,7 +68,7 @@ namespace Andy.Cli.Widgets
         {
             if (width <= 0 || maxLines <= 0) return;
 
-            var blackBg = new DL.Rgb24(0, 0, 0);
+            DL.Rgb24? bg = Themes.Theme.Current.Background; // theme surface; null (transparent) is stripped downstream
             var greenFg = new DL.Rgb24(0, 255, 0);
             var redFg = new DL.Rgb24(255, 80, 80);
             var whiteFg = new DL.Rgb24(220, 220, 220);
@@ -84,7 +84,7 @@ namespace Andy.Cli.Widgets
             {
                 if (currentLine >= startLine && renderedLines < maxLines)
                 {
-                    b.DrawText(new DL.TextRun(x, y + renderedLines, _title, whiteFg, blackBg, DL.CellAttrFlags.Bold));
+                    b.DrawText(new DL.TextRun(x, y + renderedLines, _title, whiteFg, bg, DL.CellAttrFlags.Bold));
                     renderedLines++;
                 }
                 currentLine++;
@@ -100,7 +100,7 @@ namespace Andy.Cli.Widgets
                     // Category header
                     if (currentLine >= startLine && renderedLines < maxLines)
                     {
-                        b.DrawText(new DL.TextRun(x, y + renderedLines, entry.CategoryName + " Tools:", cyanFg, blackBg, DL.CellAttrFlags.Bold));
+                        b.DrawText(new DL.TextRun(x, y + renderedLines, entry.CategoryName + " Tools:", cyanFg, bg, DL.CellAttrFlags.Bold));
                         renderedLines++;
                     }
                     currentLine++;
@@ -115,22 +115,22 @@ namespace Andy.Cli.Widgets
 
                         // Render status indicator with brackets
                         int pos = x + 2; // Indent tools
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "[", whiteFg, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "[", whiteFg, bg, DL.CellAttrFlags.None));
                         pos += 1;
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, status, statusColor, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, status, statusColor, bg, DL.CellAttrFlags.None));
                         pos += status.Length;
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "] ", whiteFg, blackBg, DL.CellAttrFlags.None));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, "] ", whiteFg, bg, DL.CellAttrFlags.None));
                         pos += 2;
 
                         // Render tool name
-                        b.DrawText(new DL.TextRun(pos, y + renderedLines, entry.ToolName, whiteFg, blackBg, DL.CellAttrFlags.Bold));
+                        b.DrawText(new DL.TextRun(pos, y + renderedLines, entry.ToolName, whiteFg, bg, DL.CellAttrFlags.Bold));
                         pos += entry.ToolName?.Length ?? 0;
 
                         // Render tool ID if present
                         if (!string.IsNullOrEmpty(entry.ToolId))
                         {
                             var idText = $" (ID: {entry.ToolId})";
-                            b.DrawText(new DL.TextRun(pos, y + renderedLines, idText, grayFg, blackBg, DL.CellAttrFlags.None));
+                            b.DrawText(new DL.TextRun(pos, y + renderedLines, idText, grayFg, bg, DL.CellAttrFlags.None));
                         }
 
                         renderedLines++;
@@ -142,7 +142,7 @@ namespace Andy.Cli.Widgets
                     {
                         if (currentLine >= startLine && renderedLines < maxLines)
                         {
-                            b.DrawText(new DL.TextRun(x + 7, y + renderedLines, entry.Description, grayFg, blackBg, DL.CellAttrFlags.None));
+                            b.DrawText(new DL.TextRun(x + 7, y + renderedLines, entry.Description, grayFg, bg, DL.CellAttrFlags.None));
                             renderedLines++;
                         }
                         currentLine++;
@@ -154,7 +154,7 @@ namespace Andy.Cli.Widgets
                         if (currentLine >= startLine && renderedLines < maxLines)
                         {
                             var permStr = $"Requires: {entry.Permissions}";
-                            b.DrawText(new DL.TextRun(x + 7, y + renderedLines, permStr, yellowFg, blackBg, DL.CellAttrFlags.None));
+                            b.DrawText(new DL.TextRun(x + 7, y + renderedLines, permStr, yellowFg, bg, DL.CellAttrFlags.None));
                             renderedLines++;
                         }
                         currentLine++;

--- a/tests/Andy.Cli.Tests/Widgets/ThemedBackgroundTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/ThemedBackgroundTests.cs
@@ -95,4 +95,45 @@ public class ThemedBackgroundTests
         Assert.Contains(OpaqueBg, RectFills(dl).Select(f => f ?? default));
         Assert.All(TextBgs(dl), bg => Assert.Equal(OpaqueBg, bg));
     }
+
+    // ----- Feed list/separator items -----
+
+    [Fact]
+    public void ModelListItem_OpaqueTheme_PaintsThemeBackground()
+    {
+        var dl = Render(Opaque(), b =>
+        {
+            var item = new ModelListItem("Available Models");
+            item.RenderSlice(0, 0, 40, 0, 5, new DL.DisplayListBuilder().Build(), b);
+        });
+        var bgs = TextBgs(dl);
+        Assert.NotEmpty(bgs);
+        Assert.All(bgs, bg => Assert.Equal(OpaqueBg, bg));
+    }
+
+    [Fact]
+    public void ToolListItem_OpaqueTheme_PaintsThemeBackground()
+    {
+        var dl = Render(Opaque(), b =>
+        {
+            var item = new ToolListItem("Available Tools");
+            item.RenderSlice(0, 0, 40, 0, 5, new DL.DisplayListBuilder().Build(), b);
+        });
+        var bgs = TextBgs(dl);
+        Assert.NotEmpty(bgs);
+        Assert.All(bgs, bg => Assert.Equal(OpaqueBg, bg));
+    }
+
+    [Fact]
+    public void ResponseSeparator_OpaqueTheme_PaintsThemeBackground()
+    {
+        var dl = Render(Opaque(), b =>
+        {
+            var sep = new ResponseSeparatorItem(inputTokens: 10, outputTokens: 20);
+            sep.RenderSlice(0, 0, 40, 0, 1, new DL.DisplayListBuilder().Build(), b);
+        });
+        var bgs = TextBgs(dl);
+        Assert.NotEmpty(bgs);
+        Assert.All(bgs, bg => Assert.Equal(OpaqueBg, bg));
+    }
 }


### PR DESCRIPTION
Continues the background sweep: ResponseSeparatorItem, ModelListItem (the /list output) and ToolListItem baked a black background and showed as black blocks under opaque themes. Now they use the theme background. Tests extended to cover all six themed status/feed widgets. Full suite: 430 passed / 1 skipped.