### PR TITLE
Collapse blank-line runs and add a blank line before markdown headings

### DIFF
--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -911,7 +911,8 @@ namespace Andy.Cli.Widgets
         /// <summary>Create a markdown item from raw markdown text.</summary>
         public MarkdownItem(string markdown)
         {
-            _lines = (markdown ?? string.Empty).Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+            // Collapse blank-line runs and ensure a blank line before headings.
+            _lines = FeedMarkdown.Normalize(markdown ?? string.Empty).Split('\n');
         }
         /// <inheritdoc />
         public int MeasureLineCount(int width)
@@ -947,6 +948,48 @@ namespace Andy.Cli.Widgets
         }
     }
 
+    /// <summary>
+    /// Normalizes markdown before it is rendered into the feed: collapses any run of
+    /// blank (or whitespace-only) lines down to a single blank line, and guarantees a
+    /// single blank line before every markdown heading. Leading/trailing blanks are
+    /// trimmed. This keeps the rendered output from showing multiple consecutive blank
+    /// lines and gives headings consistent separation.
+    /// </summary>
+    public static class FeedMarkdown
+    {
+        public static string Normalize(string md)
+        {
+            if (string.IsNullOrEmpty(md)) return md ?? string.Empty;
+
+            var lines = md.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+            var outp = new List<string>(lines.Length);
+            foreach (var raw in lines)
+            {
+                if (string.IsNullOrWhiteSpace(raw))
+                {
+                    // Collapse: only keep a blank line if something precedes it and the
+                    // previous kept line is not already blank.
+                    if (outp.Count > 0 && outp[^1].Length != 0) outp.Add("");
+                    continue;
+                }
+
+                // Ensure a blank line before a heading (unless it starts the content).
+                if (IsHeading(raw) && outp.Count > 0 && outp[^1].Length != 0) outp.Add("");
+                outp.Add(raw);
+            }
+
+            while (outp.Count > 0 && outp[^1].Length == 0) outp.RemoveAt(outp.Count - 1);
+            return string.Join("\n", outp);
+        }
+
+        private static bool IsHeading(string line)
+        {
+            var t = line.TrimStart();
+            return t.StartsWith("# ") || t.StartsWith("## ") || t.StartsWith("### ")
+                || t.StartsWith("#### ") || t.StartsWith("##### ") || t.StartsWith("###### ");
+        }
+    }
+
     /// <summary>Markdown feed item that uses Andy.Tui.Widgets.MarkdownRenderer for improved inline formatting.</summary>
     public sealed class MarkdownRendererItem : IFeedItem
     {
@@ -961,6 +1004,8 @@ namespace Andy.Cli.Widgets
             _md = _originalMd;
             // Replace standalone "You" but not "You:" in user prompts
             _md = System.Text.RegularExpressions.Regex.Replace(_md, @"\bYou\b(?!:)", "Y\u200Cou");
+            // Collapse blank-line runs and ensure a blank line before headings.
+            _md = FeedMarkdown.Normalize(_md);
 
             // Note: Paragraph spacing is handled by Andy.Tui.Widgets.MarkdownRenderer
             // during rendering, so we don't need to do it here
@@ -1675,7 +1720,7 @@ namespace Andy.Cli.Widgets
             var theme = Themes.Theme.Current;
             if (theme.Background is { } mdBg)
                 renderer.SetColors(theme.Text, mdBg, theme.Accent);
-            renderer.SetText(_content.ToString());
+            renderer.SetText(FeedMarkdown.Normalize(_content.ToString()));
             renderer.Render(new L.Rect(x, y, width, maxLines), baseDl, b);
 
             // Don't show cursor at all - it's distracting and ugly

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Widgets/CommandPaletteTests.cs" />
     <!-- Themed background tests (status/output widgets must follow the theme) -->
     <Compile Include="Widgets/ThemedBackgroundTests.cs" />
+    <!-- Feed markdown normalization (blank-line collapsing + heading spacing) -->
+    <Compile Include="Widgets/FeedMarkdownTests.cs" />
     <!-- PromptLine soft-wrapping + cursor navigation tests -->
     <Compile Include="Widgets/PromptLineWrappingTests.cs" />
     <!-- FeedView reflow signal tests (margin residue fix) -->

--- a/tests/Andy.Cli.Tests/Widgets/FeedMarkdownTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/FeedMarkdownTests.cs
@@ -1,0 +1,59 @@
+using Andy.Cli.Widgets;
+using Xunit;
+
+namespace Andy.Cli.Tests.Widgets;
+
+/// <summary>
+/// Markdown shown in the feed must not contain runs of blank lines, and headings must
+/// have a single blank line before them.
+/// </summary>
+public class FeedMarkdownTests
+{
+    [Fact]
+    public void CollapsesRunsOfBlankLinesToOne()
+    {
+        Assert.Equal("a\n\nb", FeedMarkdown.Normalize("a\n\n\n\nb"));
+        Assert.Equal("a\n\nb", FeedMarkdown.Normalize("a\n\n\nb"));
+        Assert.Equal("a\n\nb", FeedMarkdown.Normalize("a\n\nb"));
+    }
+
+    [Fact]
+    public void CollapsesWhitespaceOnlyLines()
+    {
+        Assert.Equal("a\n\nb", FeedMarkdown.Normalize("a\n  \n\t\n   \nb"));
+    }
+
+    [Fact]
+    public void NormalizesCrlfAndTrimsLeadingTrailingBlanks()
+    {
+        Assert.Equal("a\n\nb", FeedMarkdown.Normalize("\r\n\r\na\r\n\r\n\r\nb\r\n\r\n"));
+    }
+
+    [Fact]
+    public void InsertsBlankLineBeforeHeadings()
+    {
+        Assert.Equal("text\n\n## Heading", FeedMarkdown.Normalize("text\n## Heading"));
+        Assert.Equal("text\n\n# H1\n\n## H2", FeedMarkdown.Normalize("text\n# H1\n## H2"));
+    }
+
+    [Fact]
+    public void DoesNotDoubleBlankBeforeHeadingWhenAlreadyPresent()
+    {
+        Assert.Equal("text\n\n## Heading", FeedMarkdown.Normalize("text\n\n\n## Heading"));
+    }
+
+    [Fact]
+    public void DoesNotAddLeadingBlankWhenHeadingStartsContent()
+    {
+        // A blank line is inserted only BEFORE a heading, not after it, and never at the
+        // very start of the content.
+        Assert.Equal("# Title\nbody", FeedMarkdown.Normalize("# Title\nbody"));
+    }
+
+    [Fact]
+    public void EmptyInputStaysEmpty()
+    {
+        Assert.Equal(string.Empty, FeedMarkdown.Normalize(""));
+        Assert.Equal(string.Empty, FeedMarkdown.Normalize("\n\n\n"));
+    }
+}


### PR DESCRIPTION
Feed markdown could show multiple consecutive blank lines and inconsistent heading spacing. Adds FeedMarkdown.Normalize (collapse blank runs to one; one blank line before each heading; CRLF normalize; trim) applied to all feed markdown paths. Tests included. Full suite: 437 passed / 1 skipped.