### PR TITLE
Show full command/path in the permission dialog (wrap + scroll)

### DIFF
--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -823,8 +823,7 @@ class Program
                 string[] labels = { "Allow once", "Allow (session)", "Deny" };
                 int selected = 2; // default to the safe choice
                 bool open = true;
-
-                string Trunc(string s, int max) => s.Length <= max ? s : s[..Math.Max(0, max - 1)] + "…";
+                int scroll = 0; // first visible wrapped summary line
 
                 while (open)
                 {
@@ -832,24 +831,47 @@ class Program
                     pb.PushClip(new DL.ClipPush(0, 0, viewport.Width, viewport.Height));
                     pb.DrawRect(new DL.Rect(0, 0, viewport.Width, viewport.Height, new DL.Rgb24(0, 0, 0)));
 
-                    int bw = Math.Min(64, viewport.Width - 4);
-                    int bh = 9;
+                    var panelBg = new DL.Rgb24(30, 30, 40);
+                    int bw = Math.Min(Math.Max(48, viewport.Width - 4), 96);
+                    int iw = Math.Max(8, bw - 4);
+
+                    var toolLine = $"Tool: {request.ToolDisplayName ?? request.ToolId}";
+                    var summaryLines = Andy.Cli.Widgets.TextWrap.Wrap(request.ActionSummary, iw);
+
+                    // Grow the dialog to show as many summary lines as fit; scroll if longer.
+                    const int chrome = 8; // borders(2) + title + blank + tool + blank + buttons + hints
+                    int maxSummary = Math.Max(1, viewport.Height - 2 - chrome);
+                    int summaryVisible = Math.Min(summaryLines.Count, maxSummary);
+                    int maxScroll = Math.Max(0, summaryLines.Count - summaryVisible);
+                    scroll = Math.Clamp(scroll, 0, maxScroll);
+
+                    int bh = summaryVisible + chrome;
                     int bx = (viewport.Width - bw) / 2;
-                    int by = (viewport.Height - bh) / 2;
+                    int by = Math.Max(0, (viewport.Height - bh) / 2);
 
                     pb.PushClip(new DL.ClipPush(bx, by, bw, bh));
-                    pb.DrawRect(new DL.Rect(bx, by, bw, bh, new DL.Rgb24(30, 30, 40)));
+                    pb.DrawRect(new DL.Rect(bx, by, bw, bh, panelBg));
                     pb.DrawBorder(new DL.Border(bx, by, bw, bh, "double", new DL.Rgb24(200, 200, 80)));
 
                     string title = "Permission required";
-                    pb.DrawText(new DL.TextRun(bx + (bw - title.Length) / 2, by + 1, title, new DL.Rgb24(255, 255, 255), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.Bold));
+                    pb.DrawText(new DL.TextRun(bx + (bw - title.Length) / 2, by + 1, title, new DL.Rgb24(255, 255, 255), panelBg, DL.CellAttrFlags.Bold));
 
-                    var tool = Trunc($"Tool: {request.ToolDisplayName ?? request.ToolId}", bw - 4);
-                    pb.DrawText(new DL.TextRun(bx + 2, by + 3, tool, new DL.Rgb24(220, 220, 160), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.None));
-                    var summary = Trunc(request.ActionSummary, bw - 4);
-                    pb.DrawText(new DL.TextRun(bx + 2, by + 4, summary, new DL.Rgb24(200, 200, 210), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.None));
+                    var tool = toolLine.Length <= iw ? toolLine : toolLine[..Math.Max(0, iw - 1)] + "…";
+                    pb.DrawText(new DL.TextRun(bx + 2, by + 3, tool, new DL.Rgb24(220, 220, 160), panelBg, DL.CellAttrFlags.None));
 
-                    int btnY = by + 6;
+                    if (maxScroll > 0)
+                    {
+                        string pos = $"[{scroll + 1}-{scroll + summaryVisible}/{summaryLines.Count} ↑↓]";
+                        pb.DrawText(new DL.TextRun(bx + bw - 2 - pos.Length, by + 3, pos, new DL.Rgb24(150, 150, 170), panelBg, DL.CellAttrFlags.None));
+                    }
+
+                    int sy = by + 4;
+                    for (int i = 0; i < summaryVisible; i++)
+                    {
+                        pb.DrawText(new DL.TextRun(bx + 2, sy + i, summaryLines[scroll + i], new DL.Rgb24(200, 200, 210), panelBg, DL.CellAttrFlags.None));
+                    }
+
+                    int btnY = sy + summaryVisible + 1;
                     int x = bx + 2;
                     for (int i = 0; i < labels.Length; i++)
                     {
@@ -862,8 +884,8 @@ class Program
                         x += text.Length + 2;
                     }
 
-                    string hints = "← → Navigate  Enter Select  Esc Deny";
-                    pb.DrawText(new DL.TextRun(bx + (bw - hints.Length) / 2, by + bh - 1, hints, new DL.Rgb24(120, 120, 150), new DL.Rgb24(30, 30, 40), DL.CellAttrFlags.None));
+                    string hints = maxScroll > 0 ? "← → Select  ↑ ↓ Scroll  Enter Confirm  Esc Deny" : "← → Navigate  Enter Select  Esc Deny";
+                    pb.DrawText(new DL.TextRun(bx + Math.Max(2, (bw - hints.Length) / 2), by + bh - 1, hints, new DL.Rgb24(120, 120, 150), panelBg, DL.CellAttrFlags.None));
 
                     pb.Pop();
                     await scheduler.RenderOnceAsync(pb.Build(), viewport, caps, pty, CancellationToken.None);
@@ -871,6 +893,10 @@ class Program
                     var k = ReadKeyBlocking();
                     if (k.Key == ConsoleKey.LeftArrow) selected = (selected + labels.Length - 1) % labels.Length;
                     else if (k.Key == ConsoleKey.RightArrow || k.Key == ConsoleKey.Tab) selected = (selected + 1) % labels.Length;
+                    else if (k.Key == ConsoleKey.UpArrow) scroll -= 1;
+                    else if (k.Key == ConsoleKey.DownArrow) scroll += 1;
+                    else if (k.Key == ConsoleKey.PageUp) scroll -= 5;
+                    else if (k.Key == ConsoleKey.PageDown) scroll += 5;
                     else if (k.Key == ConsoleKey.Escape || k.Key == ConsoleKey.D || k.Key == ConsoleKey.N) { selected = 2; open = false; }
                     else if (k.Key == ConsoleKey.Enter || k.Key == ConsoleKey.Spacebar) open = false;
                 }

--- a/src/Andy.Cli/Widgets/TextWrap.cs
+++ b/src/Andy.Cli/Widgets/TextWrap.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Andy.Cli.Widgets
+{
+    /// <summary>Text wrapping helpers for dialogs and panels.</summary>
+    public static class TextWrap
+    {
+        /// <summary>
+        /// Word-wrap text to the given column width, hard-breaking tokens that are longer
+        /// than the width (paths, URLs and commands often have no spaces) so nothing is
+        /// truncated. Existing line breaks are preserved; blank lines are kept.
+        /// </summary>
+        public static List<string> Wrap(string s, int width)
+        {
+            if (width < 1) width = 1;
+            var outl = new List<string>();
+            foreach (var rawLine in (s ?? string.Empty).Replace("\r\n", "\n").Replace('\r', '\n').Split('\n'))
+            {
+                if (rawLine.Length == 0) { outl.Add(string.Empty); continue; }
+                var cur = new StringBuilder();
+                foreach (var word in rawLine.Split(' '))
+                {
+                    var w = word;
+                    while (w.Length > width)
+                    {
+                        if (cur.Length > 0) { outl.Add(cur.ToString()); cur.Clear(); }
+                        outl.Add(w.Substring(0, width));
+                        w = w.Substring(width);
+                    }
+                    if (cur.Length == 0) cur.Append(w);
+                    else if (cur.Length + 1 + w.Length <= width) { cur.Append(' '); cur.Append(w); }
+                    else { outl.Add(cur.ToString()); cur.Clear(); cur.Append(w); }
+                }
+                outl.Add(cur.ToString());
+            }
+            return outl;
+        }
+    }
+}

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -61,6 +61,8 @@
     <Compile Include="Widgets/ThemedBackgroundTests.cs" />
     <!-- Feed markdown normalization (blank-line collapsing + heading spacing) -->
     <Compile Include="Widgets/FeedMarkdownTests.cs" />
+    <!-- Text wrapping (permission dialog, panels) -->
+    <Compile Include="Widgets/TextWrapTests.cs" />
     <!-- PromptLine soft-wrapping + cursor navigation tests -->
     <Compile Include="Widgets/PromptLineWrappingTests.cs" />
     <!-- FeedView reflow signal tests (margin residue fix) -->

--- a/tests/Andy.Cli.Tests/Widgets/TextWrapTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/TextWrapTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using Andy.Cli.Widgets;
+using Xunit;
+
+namespace Andy.Cli.Tests.Widgets;
+
+public class TextWrapTests
+{
+    [Fact]
+    public void ShortText_StaysOnOneLine()
+    {
+        var lines = TextWrap.Wrap("short", 20);
+        Assert.Equal(new[] { "short" }, lines);
+    }
+
+    [Fact]
+    public void WordWrapsAtSpaces()
+    {
+        var lines = TextWrap.Wrap("the quick brown fox", 9);
+        Assert.All(lines, l => Assert.True(l.Length <= 9, $"'{l}' exceeds width"));
+        Assert.Equal("the quick brown fox", string.Join(" ", lines));
+    }
+
+    [Fact]
+    public void HardBreaksLongTokensSoNothingIsTruncated()
+    {
+        // A long path/command with no spaces must still be fully visible across lines.
+        var path = "/Users/sam/Devel/some/really/long/path/to/a/file-with-a-long-name.txt";
+        var lines = TextWrap.Wrap(path, 16);
+        Assert.All(lines, l => Assert.True(l.Length <= 16));
+        Assert.Equal(path, string.Concat(lines)); // reassembling loses nothing
+    }
+
+    [Fact]
+    public void PreservesExistingLineBreaksAndBlankLines()
+    {
+        var lines = TextWrap.Wrap("a\n\nb", 20);
+        Assert.Equal(new[] { "a", "", "b" }, lines);
+    }
+
+    [Fact]
+    public void HandlesNullAndEmpty()
+    {
+        Assert.Equal(new[] { "" }, TextWrap.Wrap("", 10));
+        Assert.Equal(new[] { "" }, TextWrap.Wrap(null!, 10));
+    }
+}


### PR DESCRIPTION
The permission approval dialog truncated long commands/paths to one line. Now it wraps the action summary across lines (hard-breaking long tokens), grows to fit, and scrolls (Up/Down/PageUp/PageDown) when needed, so the full command/path is always readable. Adds a tested TextWrap helper. Full suite green.