### PR TITLE
Theme-colored syntax highlighting for code blocks (no underline)

### DIFF
--- a/src/Andy.Cli/Themes/Theme.cs
+++ b/src/Andy.Cli/Themes/Theme.cs
@@ -62,6 +62,16 @@ namespace Andy.Cli.Themes
         public DL.Rgb24 Heading { get; set; } = new DL.Rgb24(200, 200, 80);
         public DL.Rgb24 Code { get; set; } = new DL.Rgb24(180, 180, 180);
         public DL.Rgb24 Ghost { get; set; } = new DL.Rgb24(100, 100, 100);
+
+        // Syntax highlighting colors for code blocks and inline code. Distinct theme
+        // colors (never underlines) so keywords, types/class names, strings, comments
+        // and numbers are easy to tell apart. Defaults suit a dark background.
+        public DL.Rgb24 SyntaxKeyword { get; set; } = new DL.Rgb24(197, 134, 192); // purple
+        public DL.Rgb24 SyntaxType { get; set; } = new DL.Rgb24(78, 201, 176);  // teal
+        public DL.Rgb24 SyntaxString { get; set; } = new DL.Rgb24(206, 145, 120); // orange
+        public DL.Rgb24 SyntaxComment { get; set; } = new DL.Rgb24(106, 153, 85);  // green
+        public DL.Rgb24 SyntaxNumber { get; set; } = new DL.Rgb24(181, 206, 168); // light green
+        public DL.Rgb24 SyntaxIdentifier { get; set; } = new DL.Rgb24(220, 220, 220); // near-default
         public DL.Rgb24 Border { get; set; } = new DL.Rgb24(80, 80, 80);
         public DL.Rgb24 Separator { get; set; } = new DL.Rgb24(50, 55, 70);
         public DL.Rgb24 KeyHighlight { get; set; } = new DL.Rgb24(200, 200, 80);
@@ -153,6 +163,12 @@ namespace Andy.Cli.Themes
             Heading = new DL.Rgb24(140, 110, 0),
             Code = new DL.Rgb24(70, 70, 70),
             Ghost = new DL.Rgb24(160, 160, 160),
+            SyntaxKeyword = new DL.Rgb24(0, 0, 255),
+            SyntaxType = new DL.Rgb24(38, 127, 153),
+            SyntaxString = new DL.Rgb24(163, 21, 21),
+            SyntaxComment = new DL.Rgb24(0, 128, 0),
+            SyntaxNumber = new DL.Rgb24(9, 134, 88),
+            SyntaxIdentifier = new DL.Rgb24(40, 40, 40),
             Border = new DL.Rgb24(170, 170, 170),
             Separator = new DL.Rgb24(180, 185, 200),
             KeyHighlight = new DL.Rgb24(140, 110, 0),
@@ -219,6 +235,12 @@ namespace Andy.Cli.Themes
                 Heading = C(TS.ThemeToken.Accent),
                 Code = C(TS.ThemeToken.SyntaxPreproc),
                 Ghost = C(TS.ThemeToken.ForegroundMuted),
+                SyntaxKeyword = C(TS.ThemeToken.SyntaxKeyword),
+                SyntaxType = C(TS.ThemeToken.SyntaxPreproc),
+                SyntaxString = C(TS.ThemeToken.SyntaxString),
+                SyntaxComment = C(TS.ThemeToken.SyntaxComment),
+                SyntaxNumber = C(TS.ThemeToken.SyntaxNumber),
+                SyntaxIdentifier = C(TS.ThemeToken.Foreground),
                 Border = C(TS.ThemeToken.Border),
                 Separator = C(TS.ThemeToken.Border),
                 KeyHighlight = C(TS.ThemeToken.Warning),

--- a/src/Andy.Cli/Widgets/CodeHighlighter.cs
+++ b/src/Andy.Cli/Widgets/CodeHighlighter.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using Andy.Cli.Themes;
+using DL = Andy.Tui.DisplayList;
+
+namespace Andy.Cli.Widgets
+{
+    /// <summary>The kind of token produced by <see cref="CodeHighlighter"/>.</summary>
+    public enum SyntaxKind { Default, Keyword, Type, String, Comment, Number, Identifier }
+
+    /// <summary>Theme colors for syntax highlighting.</summary>
+    public readonly struct SyntaxPalette
+    {
+        public readonly DL.Rgb24 Keyword, Type, Str, Comment, Number, Identifier, Default;
+
+        public SyntaxPalette(DL.Rgb24 keyword, DL.Rgb24 type, DL.Rgb24 str, DL.Rgb24 comment,
+                             DL.Rgb24 number, DL.Rgb24 identifier, DL.Rgb24 def)
+        {
+            Keyword = keyword; Type = type; Str = str; Comment = comment;
+            Number = number; Identifier = identifier; Default = def;
+        }
+
+        public DL.Rgb24 ColorFor(SyntaxKind k) => k switch
+        {
+            SyntaxKind.Keyword => Keyword,
+            SyntaxKind.Type => Type,
+            SyntaxKind.String => Str,
+            SyntaxKind.Comment => Comment,
+            SyntaxKind.Number => Number,
+            SyntaxKind.Identifier => Identifier,
+            _ => Default,
+        };
+
+        public static SyntaxPalette FromTheme(Theme t) => new(
+            t.SyntaxKeyword, t.SyntaxType, t.SyntaxString, t.SyntaxComment,
+            t.SyntaxNumber, t.SyntaxIdentifier, t.Code);
+    }
+
+    /// <summary>
+    /// A small, language-agnostic syntax tokenizer for code blocks and inline code.
+    /// Distinguishes keywords, types/class names, method calls, strings, comments and
+    /// numbers by color (never by underline). Knows C# and Python keyword sets; other
+    /// languages fall back to C#-style comments/strings.
+    /// </summary>
+    public static class CodeHighlighter
+    {
+        private static readonly HashSet<string> CsKeywords = new(StringComparer.Ordinal)
+        {
+            "using", "namespace", "class", "struct", "interface", "enum", "record", "public",
+            "private", "protected", "internal", "static", "readonly", "const", "void", "var",
+            "new", "return", "async", "await", "if", "else", "for", "foreach", "while", "do",
+            "switch", "case", "default", "break", "continue", "throw", "try", "catch", "finally",
+            "true", "false", "null", "this", "base", "override", "virtual", "abstract", "sealed",
+            "in", "out", "ref", "is", "as", "get", "set",
+        };
+
+        private static readonly HashSet<string> PyKeywords = new(StringComparer.Ordinal)
+        {
+            "def", "class", "return", "if", "elif", "else", "for", "while", "import", "from",
+            "as", "True", "False", "None", "in", "and", "or", "not", "with", "yield", "lambda",
+            "try", "except", "finally", "raise", "pass", "break", "continue", "global", "nonlocal",
+            "is", "assert", "async", "await", "del",
+        };
+
+        public static List<(string Text, SyntaxKind Kind)> Tokenize(string line, string? lang)
+        {
+            var result = new List<(string, SyntaxKind)>();
+            if (string.IsNullOrEmpty(line)) return result;
+
+            bool py = lang != null && lang.StartsWith("py", StringComparison.OrdinalIgnoreCase);
+            var keywords = py ? PyKeywords : CsKeywords;
+            int n = line.Length, i = 0;
+
+            while (i < n)
+            {
+                char c = line[i];
+
+                // Line comments
+                if (!py && c == '/' && i + 1 < n && line[i + 1] == '/') { result.Add((line.Substring(i), SyntaxKind.Comment)); break; }
+                if (py && c == '#') { result.Add((line.Substring(i), SyntaxKind.Comment)); break; }
+
+                // String literals
+                if (c == '"' || (py && c == '\''))
+                {
+                    char q = c; int j = i + 1;
+                    while (j < n && line[j] != q) { if (line[j] == '\\' && j + 1 < n) j += 2; else j++; }
+                    j = Math.Min(n, j + 1);
+                    result.Add((line.Substring(i, j - i), SyntaxKind.String)); i = j; continue;
+                }
+
+                // Whitespace
+                if (char.IsWhiteSpace(c))
+                {
+                    int j = i; while (j < n && char.IsWhiteSpace(line[j])) j++;
+                    result.Add((line.Substring(i, j - i), SyntaxKind.Default)); i = j; continue;
+                }
+
+                // Numbers
+                if (char.IsDigit(c))
+                {
+                    int j = i; while (j < n && (char.IsLetterOrDigit(line[j]) || line[j] == '.' || line[j] == '_' || line[j] == 'x')) j++;
+                    result.Add((line.Substring(i, j - i), SyntaxKind.Number)); i = j; continue;
+                }
+
+                // Identifiers / keywords / types / method calls
+                if (char.IsLetter(c) || c == '_')
+                {
+                    int j = i + 1; while (j < n && (char.IsLetterOrDigit(line[j]) || line[j] == '_')) j++;
+                    string tok = line.Substring(i, j - i);
+                    SyntaxKind kind;
+                    if (keywords.Contains(tok))
+                    {
+                        kind = SyntaxKind.Keyword;
+                    }
+                    else
+                    {
+                        int k = j; while (k < n && char.IsWhiteSpace(line[k])) k++;
+                        bool isCall = k < n && line[k] == '(';       // method/function call
+                        bool isType = char.IsUpper(tok[0]);          // class/type name (PascalCase)
+                        kind = (isCall || isType) ? SyntaxKind.Type : SyntaxKind.Identifier;
+                    }
+                    result.Add((tok, kind)); i = j; continue;
+                }
+
+                // Punctuation / operators
+                result.Add((line[i].ToString(), SyntaxKind.Default)); i++;
+            }
+
+            return result;
+        }
+
+        public static IEnumerable<(string Text, DL.Rgb24 Color)> Highlight(string line, string? lang, SyntaxPalette palette)
+        {
+            foreach (var (text, kind) in Tokenize(line, lang))
+                yield return (text, palette.ColorFor(kind));
+        }
+    }
+}

--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -1380,53 +1380,11 @@ namespace Andy.Cli.Widgets
 
         private static IEnumerable<(string Text, DL.Rgb24 Color, DL.CellAttrFlags Attr)> Highlight(string line, string? lang)
         {
-            var normal = new DL.Rgb24(200, 200, 220);
-            var keyword = new DL.Rgb24(180, 220, 180);
-            var typecol = new DL.Rgb24(180, 200, 240);
-            var str = new DL.Rgb24(220, 200, 160);
-            var com = new DL.Rgb24(120, 140, 120);
-            // Comments
-            if (lang != null && lang.StartsWith("py"))
-            {
-                int hash = line.IndexOf('#');
-                string code = hash >= 0 ? line.Substring(0, hash) : line;
-                foreach (var part in TokenizePython(code)) yield return part;
-                if (hash >= 0) yield return (line.Substring(hash), com, DL.CellAttrFlags.None);
-                yield break;
-            }
-            else // default to C#-like
-            {
-                int sl = line.IndexOf("//");
-                string code = sl >= 0 ? line.Substring(0, sl) : line;
-                foreach (var part in TokenizeCSharp(code)) yield return part;
-                if (sl >= 0) yield return (line.Substring(sl), com, DL.CellAttrFlags.None);
-                yield break;
-            }
-
-            static IEnumerable<(string, DL.Rgb24, DL.CellAttrFlags)> TokenizeCSharp(string code)
-            {
-                var keywords = new HashSet<string>(new[] { "using", "namespace", "class", "public", "private", "protected", "internal", "static", "void", "int", "string", "var", "new", "return", "async", "await", "if", "else", "for", "foreach", "while", "switch", "case", "break", "true", "false" });
-                int i = 0; while (i < code.Length)
-                {
-                    char c = code[i];
-                    if (char.IsWhiteSpace(c)) { int j = i; while (j < code.Length && char.IsWhiteSpace(code[j])) j++; yield return (code.Substring(i, j - i), new DL.Rgb24(200, 200, 220), DL.CellAttrFlags.None); i = j; continue; }
-                    if (c == '"') { int j = i + 1; while (j < code.Length && code[j] != '"') { if (code[j] == '\\' && j + 1 < code.Length) j += 2; else j++; } j = Math.Min(code.Length, j + 1); yield return (code.Substring(i, j - i), new DL.Rgb24(220, 200, 160), DL.CellAttrFlags.None); i = j; continue; }
-                    if (char.IsLetter(c) || c == '_') { int j = i + 1; while (j < code.Length && (char.IsLetterOrDigit(code[j]) || code[j] == '_')) j++; var tok = code.Substring(i, j - i); var col = keywords.Contains(tok) ? new DL.Rgb24(180, 220, 180) : new DL.Rgb24(200, 200, 220); yield return (tok, col, DL.CellAttrFlags.None); i = j; continue; }
-                    yield return (code[i].ToString(), new DL.Rgb24(200, 200, 220), DL.CellAttrFlags.None); i++;
-                }
-            }
-            static IEnumerable<(string, DL.Rgb24, DL.CellAttrFlags)> TokenizePython(string code)
-            {
-                var keywords = new HashSet<string>(new[] { "def", "class", "return", "if", "elif", "else", "for", "while", "import", "from", "as", "True", "False", "None", "in", "and", "or", "not", "with", "yield" });
-                int i = 0; while (i < code.Length)
-                {
-                    char c = code[i];
-                    if (char.IsWhiteSpace(c)) { int j = i; while (j < code.Length && char.IsWhiteSpace(code[j])) j++; yield return (code.Substring(i, j - i), new DL.Rgb24(200, 200, 220), DL.CellAttrFlags.None); i = j; continue; }
-                    if (c == '"' || c == '\'') { char q = c; int j = i + 1; while (j < code.Length && code[j] != q) { if (code[j] == '\\' && j + 1 < code.Length) j += 2; else j++; } j = Math.Min(code.Length, j + 1); yield return (code.Substring(i, j - i), new DL.Rgb24(220, 200, 160), DL.CellAttrFlags.None); i = j; continue; }
-                    if (char.IsLetter(c) || c == '_') { int j = i + 1; while (j < code.Length && (char.IsLetterOrDigit(code[j]) || code[j] == '_')) j++; var tok = code.Substring(i, j - i); var col = keywords.Contains(tok) ? new DL.Rgb24(180, 220, 180) : new DL.Rgb24(200, 200, 220); yield return (tok, col, DL.CellAttrFlags.None); i = j; continue; }
-                    yield return (code[i].ToString(), new DL.Rgb24(200, 200, 220), DL.CellAttrFlags.None); i++;
-                }
-            }
+            // Theme-colored, never underlined: keywords, types/class names, method calls,
+            // strings, comments and numbers each get a distinct theme color.
+            var palette = SyntaxPalette.FromTheme(Themes.Theme.Current);
+            foreach (var (text, color) in CodeHighlighter.Highlight(line, lang, palette))
+                yield return (text, color, DL.CellAttrFlags.None);
         }
     }
 

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -63,6 +63,8 @@
     <Compile Include="Widgets/FeedMarkdownTests.cs" />
     <!-- Text wrapping (permission dialog, panels) -->
     <Compile Include="Widgets/TextWrapTests.cs" />
+    <!-- Code syntax highlighting (theme colors, no underline) -->
+    <Compile Include="Widgets/CodeHighlighterTests.cs" />
     <!-- PromptLine soft-wrapping + cursor navigation tests -->
     <Compile Include="Widgets/PromptLineWrappingTests.cs" />
     <!-- FeedView reflow signal tests (margin residue fix) -->

--- a/tests/Andy.Cli.Tests/Widgets/CodeHighlighterTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/CodeHighlighterTests.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using Andy.Cli.Widgets;
+using Xunit;
+
+namespace Andy.Cli.Tests.Widgets;
+
+public class CodeHighlighterTests
+{
+    private static SyntaxKind KindOf(string line, string lang, string token) =>
+        CodeHighlighter.Tokenize(line, lang).First(t => t.Text == token).Kind;
+
+    [Fact]
+    public void ClassifiesCSharpTokens()
+    {
+        var toks = CodeHighlighter.Tokenize("public void Foo() { return 42; } // hi", "csharp");
+        Assert.Equal(SyntaxKind.Keyword, toks.First(t => t.Text == "public").Kind);
+        Assert.Equal(SyntaxKind.Keyword, toks.First(t => t.Text == "return").Kind);
+        Assert.Equal(SyntaxKind.Number, toks.First(t => t.Text == "42").Kind);
+        Assert.Equal(SyntaxKind.Comment, toks.First(t => t.Text.StartsWith("//")).Kind);
+    }
+
+    [Fact]
+    public void MethodCallsAndClassNamesAreTypeColored()
+    {
+        // PascalCase identifier => type/class name; identifier before '(' => method call.
+        Assert.Equal(SyntaxKind.Type, KindOf("var x = new Widget();", "cs", "Widget"));
+        Assert.Equal(SyntaxKind.Type, KindOf("result = compute(a, b);", "cs", "compute"));
+        Assert.Equal(SyntaxKind.Identifier, KindOf("result = compute(a, b);", "cs", "result"));
+    }
+
+    [Fact]
+    public void StringsAreOneToken()
+    {
+        var toks = CodeHighlighter.Tokenize("name = \"hello world\";", "cs");
+        Assert.Contains(toks, t => t.Kind == SyntaxKind.String && t.Text == "\"hello world\"");
+    }
+
+    [Fact]
+    public void PythonCommentsAndKeywords()
+    {
+        var toks = CodeHighlighter.Tokenize("def foo():  # comment", "python");
+        Assert.Equal(SyntaxKind.Keyword, toks.First(t => t.Text == "def").Kind);
+        Assert.Equal(SyntaxKind.Comment, toks.First(t => t.Text.StartsWith("#")).Kind);
+    }
+
+    [Fact]
+    public void NoTokenUsesUnderline_PaletteMapsToColors()
+    {
+        // The palette maps every kind to a distinct color; highlighting never returns attrs.
+        var p = new SyntaxPalette(
+            keyword: new Andy.Tui.DisplayList.Rgb24(1, 0, 0),
+            type: new Andy.Tui.DisplayList.Rgb24(2, 0, 0),
+            str: new Andy.Tui.DisplayList.Rgb24(3, 0, 0),
+            comment: new Andy.Tui.DisplayList.Rgb24(4, 0, 0),
+            number: new Andy.Tui.DisplayList.Rgb24(5, 0, 0),
+            identifier: new Andy.Tui.DisplayList.Rgb24(6, 0, 0),
+            def: new Andy.Tui.DisplayList.Rgb24(7, 0, 0));
+        var spans = CodeHighlighter.Highlight("class A { }", "cs", p).ToList();
+        Assert.Equal(new Andy.Tui.DisplayList.Rgb24(1, 0, 0), spans.First(s => s.Text == "class").Color);
+        Assert.Equal(new Andy.Tui.DisplayList.Rgb24(2, 0, 0), spans.First(s => s.Text == "A").Color);
+    }
+}


### PR DESCRIPTION
Code blocks now use theme colors for keywords, types/class names, method calls, strings, comments and numbers (distinct colors, never underline). Adds Syntax* theme tokens (dark/light + library mapping) and a tested, language-agnostic CodeHighlighter. First of the three places you flagged; inline code (needs a library change) and tool output to follow.