### PR TITLE
Theme the tool-execution status colors

### DIFF
--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -1561,11 +1561,10 @@ namespace Andy.Cli.Widgets
 
             int row = y;
             int drawn = 0;
-            var green = new DL.Rgb24(60, 200, 120);
-            var red = new DL.Rgb24(240, 100, 100);
-            var cyan = new DL.Rgb24(120, 200, 255);
-            var dim = new DL.Rgb24(170, 170, 170);
-            var fg = _isSuccess ? green : red;
+            var theme = Themes.Theme.Current;
+            var cyan = theme.ToolName;
+            var dim = theme.TextDim;
+            var fg = _isSuccess ? theme.Success : theme.Error;
 
             // Header (tool name highlighted)
             if (drawn < maxLines && startLine <= 0)
@@ -1592,7 +1591,7 @@ namespace Andy.Cli.Widgets
                 var space = Math.Max(0, width - label.Length);
                 var body = _resultLine.Length > space ? _resultLine.Substring(0, Math.Max(0, space - 1)) + "…" : _resultLine;
                 b.DrawText(new DL.TextRun(x, row, label, dim, null, DL.CellAttrFlags.None));
-                b.DrawText(new DL.TextRun(x + label.Length, row, body, new DL.Rgb24(210, 210, 210), null, DL.CellAttrFlags.None));
+                b.DrawText(new DL.TextRun(x + label.Length, row, body, theme.ToolResult, null, DL.CellAttrFlags.None));
             }
         }
     }

--- a/tests/Andy.Cli.Tests/Widgets/ThemedBackgroundTests.cs
+++ b/tests/Andy.Cli.Tests/Widgets/ThemedBackgroundTests.cs
@@ -125,6 +125,20 @@ public class ThemedBackgroundTests
     }
 
     [Fact]
+    public void ToolExecutionItem_UsesThemeToolColors()
+    {
+        var theme = new Theme { ToolName = new DL.Rgb24(1, 2, 3), ToolResult = new DL.Rgb24(4, 5, 6) };
+        var dl = Render(theme, b =>
+        {
+            var item = new ToolExecutionItem("read_file", new System.Collections.Generic.Dictionary<string, object?>(), "ok result", isSuccess: true);
+            item.RenderSlice(0, 0, 60, 0, 5, new DL.DisplayListBuilder().Build(), b);
+        });
+        var fgs = dl.Ops.OfType<DL.TextRun>().Select(t => t.Fg).ToList();
+        Assert.Contains(new DL.Rgb24(1, 2, 3), fgs.Select(f => f ?? default)); // tool header -> ToolName
+        Assert.Contains(new DL.Rgb24(4, 5, 6), fgs.Select(f => f ?? default)); // result body -> ToolResult
+    }
+
+    [Fact]
     public void ResponseSeparator_OpaqueTheme_PaintsThemeBackground()
     {
         var dl = Render(Opaque(), b =>


### PR DESCRIPTION
ToolExecutionItem used hardcoded colors for the tool name/params/result; now it uses the theme's ToolName/ToolResult/TextDim/Success/Error. Code-containing tool *results* flow through the markdown/code-block paths (already themed by #105, plus the pending inline-code library PR). Test added.