### PR TITLE
Integrate published Andy.CodeIndex library

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Andy.Acp.Core" Version="2025.11.18-rc.3" />
+    <PackageReference Include="Andy.CodeIndex.Infrastructure" Version="2026.6.8-rc.3" />
     <PackageReference Include="Andy.Engine" Version="2026.5.30-rc.33" />
     <PackageReference Include="Andy.Llm" Version="2026.6.7-rc.38" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -345,6 +345,11 @@ class Program
             services.AddSingleton<CodeIndexingService>();
             services.AddHostedService<CodeIndexingService>(provider => provider.GetRequiredService<CodeIndexingService>());
 
+            // Register the Andy.CodeIndex library's DB-free analysis/chunking services
+            // (Roslyn-based) so they are available in-process for semantic indexing.
+            services.AddSingleton<Andy.CodeIndex.Application.Interfaces.ICodeAnalysisService, Andy.CodeIndex.Infrastructure.Services.CodeAnalysisService>();
+            services.AddSingleton<Andy.CodeIndex.Application.Interfaces.IChunkingService, Andy.CodeIndex.Infrastructure.Services.ChunkingService>();
+
             var serviceProvider = services.BuildServiceProvider();
 
             // Initialize tool registry and register tools

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -92,6 +92,8 @@
     <Compile Include="Integration/PermissionSessionBroadeningIntegrationTests.cs" />
     <!-- list_directory tool integration tests -->
     <Compile Include="Integration/ListDirectoryIntegrationTests.cs" />
+    <!-- Andy.CodeIndex library in-process integration tests -->
+    <Compile Include="Integration/CodeIndexLibraryIntegrationTests.cs" />
     <!-- AQ1 headless config schema tests (rivoli-ai/andy-cli#46) -->
     <Compile Include="HeadlessConfig/HeadlessConfigSchemaTests.cs" />
     <!-- AQ2 headless runner tests (rivoli-ai/andy-cli#47) -->

--- a/tests/Andy.Cli.Tests/Integration/CodeIndexLibraryIntegrationTests.cs
+++ b/tests/Andy.Cli.Tests/Integration/CodeIndexLibraryIntegrationTests.cs
@@ -1,0 +1,74 @@
+using Andy.CodeIndex.Application.Interfaces;
+using Andy.CodeIndex.Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Cli.Tests.Integration;
+
+/// <summary>
+/// Confirms andy-cli integrates the published Andy.CodeIndex library: its
+/// DB-free Roslyn analysis and chunking services run in-process and produce
+/// meaningful results, both directly and when resolved through DI the way
+/// Program.cs registers them. The Postgres-backed parts of the library are
+/// out of scope for this in-process integration check.
+/// </summary>
+public class CodeIndexLibraryIntegrationTests
+{
+    private const string SampleSource = @"
+namespace Sample;
+
+public class Calculator
+{
+    public int Add(int a, int b) { return a + b; }
+    public int Subtract(int a, int b) { return a - b; }
+}
+
+public interface IGreeter
+{
+    string Greet(string name);
+}
+";
+
+    [Fact]
+    public void CodeAnalysisService_AnalyzesCSharp_ExtractsTypesAndMethods()
+    {
+        ICodeAnalysisService analysis = new CodeAnalysisService();
+
+        Assert.True(analysis.SupportsLanguage("csharp"));
+
+        var result = analysis.Analyze(SampleSource, "Calculator.cs", "csharp");
+
+        var calculator = Assert.Single(result.Classes, c => c.Name == "Calculator");
+        Assert.Contains(calculator.Methods, m => m.Name == "Add");
+        Assert.Contains(calculator.Methods, m => m.Name == "Subtract");
+        Assert.Contains(result.Interfaces, i => i.Name == "IGreeter");
+    }
+
+    [Fact]
+    public void ChunkingService_ChunksCSharp_ProducesNonEmptyChunks()
+    {
+        IChunkingService chunking = new ChunkingService();
+
+        var chunks = chunking.ChunkText(SampleSource, "Calculator.cs");
+
+        Assert.NotEmpty(chunks);
+        Assert.All(chunks, c => Assert.False(string.IsNullOrWhiteSpace(c.Content)));
+        Assert.Contains(chunks, c => c.Content.Contains("Calculator"));
+    }
+
+    [Fact]
+    public void DependencyInjection_ResolvesLibraryServices_AsRegisteredInProgram()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<ICodeAnalysisService, CodeAnalysisService>()
+            .AddSingleton<IChunkingService, ChunkingService>()
+            .BuildServiceProvider();
+
+        var analysis = provider.GetRequiredService<ICodeAnalysisService>();
+        var chunking = provider.GetRequiredService<IChunkingService>();
+
+        Assert.True(analysis.SupportsLanguage("csharp"));
+        // The chunker resolves and uses the DI-supplied analyzer.
+        Assert.NotEmpty(chunking.ChunkText(SampleSource, "Calculator.cs"));
+    }
+}


### PR DESCRIPTION
## Summary

Upgrades andy-cli to consume the newly published **Andy.CodeIndex** NuGet packages (`2026.6.8-rc.3`).

- Adds a `PackageReference` to `Andy.CodeIndex.Infrastructure` (which brings in `Application`/`Domain` transitively).
- Registers the library's **DB-free** Roslyn services — `ICodeAnalysisService` and `IChunkingService` — in DI alongside the existing code-indexing service. Singletons are lazy, so there is no startup cost unless resolved.
- Adds `Integration/CodeIndexLibraryIntegrationTests.cs` confirming the integration works in-process: C# analysis (types/methods/interfaces), text chunking, and DI resolution.

## Notes

- Only the DB-free portion of the library is exercised here. The Postgres/pgvector-backed indexing services ship transitively (Npgsql/EF Core/pgvector) but require a running database and are out of scope for this in-process integration.
- Full test suite green locally: 451 passed, 1 skipped.

## Related

Packaging/publishing set up in rivoli-ai/andy-code-index#281.