### PR TITLE
[AX.3] andy-cli: enable built-in tools in headless mode

### DIFF
--- a/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
+++ b/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
@@ -58,6 +58,26 @@ public static class HeadlessAgentRunner
         var exitCode = HeadlessExitCode.Success;
 
         await using var services = BuildServiceProvider(config, loggerFactory);
+
+        // AX.3 (rivoli-ai/conductor#2090): register the assistant's built-in
+        // tools into the SAME IToolRegistry the agent uses, so a headless
+        // coding agent actually has file/command/text tools — not just the
+        // config-declared cli/mcp tools. Mirrors the interactive path
+        // (Program.cs / ServiceConfiguration.cs): ToolCatalog.RegisterAllTools
+        // populates ToolRegistrationInfo entries in DI, which we then drain into
+        // the registry. HeadlessToolHost adds the config tools into the same
+        // registry afterwards, so built-ins and cli/mcp tools coexist.
+        //
+        // Permission caveat (AX.4 territory, NOT solved here): headless wires
+        // AddAndyCliPermissions(services, null) — fail-closed with no broker.
+        // Mutating built-ins (write_file/delete_file/move_file/copy_file/
+        // file_editor/replace_text/create_directory) resolve to "Ask" and are
+        // therefore DENIED at execution time with no interactive prompt;
+        // execute_command likewise asks via its capability. Read-only built-ins
+        // (read_file/list_directory/search_text/git_diff/etc.) stay
+        // auto-allowed. AX.4 injects the per-run allow-list that relaxes this.
+        RegisterBuiltInTools(services, loggerFactory);
+
         await using HeadlessToolHost? toolHost =
             await TryBuildToolHostAsync(config, services, loggerFactory, emitter, stderr, ct);
 
@@ -311,7 +331,9 @@ public static class HeadlessAgentRunner
         return bytes.LongLength;
     }
 
-    private static ServiceProvider BuildServiceProvider(HeadlessRunConfig config, ILoggerFactory loggerFactory)
+    // Internal for testing: lets a test exercise the real DI wiring (built-in
+    // tool catalog included) instead of reimplementing it in a parallel path.
+    internal static ServiceProvider BuildServiceProvider(HeadlessRunConfig config, ILoggerFactory loggerFactory)
     {
         var services = new ServiceCollection();
         services.AddSingleton(loggerFactory);
@@ -337,10 +359,11 @@ public static class HeadlessAgentRunner
 
         services.AddSingleton<ILlmProviderFactory, LlmProviderFactory>();
 
-        // Andy.Tools: minimal wiring — registry + executor + the validators
-        // / managers ToolExecutor depends on. We deliberately don't register
-        // any built-in tools (ToolCatalog.RegisterAllTools); the headless
-        // run's tool surface is exactly what HeadlessToolHost adds.
+        // Andy.Tools: registry + executor + the validators / managers
+        // ToolExecutor depends on. The built-in tool surface is registered as
+        // ToolRegistrationInfo entries here (AX.3) and drained into the registry
+        // in ExecuteAsync after the provider is built; HeadlessToolHost then
+        // layers the config cli/mcp tools onto the same registry.
         services.AddSingleton<Andy.Tools.Validation.IToolValidator, Andy.Tools.Validation.ToolValidator>();
         services.AddSingleton<IToolRegistry, Andy.Tools.Registry.ToolRegistry>();
         services.AddSingleton<Andy.Tools.Discovery.IToolDiscovery, Andy.Tools.Discovery.ToolDiscoveryService>();
@@ -355,12 +378,42 @@ public static class HeadlessAgentRunner
         Andy.Cli.Services.CliPermissionServiceExtensions.AddAndyCliPermissions(services, null);
         services.AddSingleton(new Andy.Tools.Framework.ToolFrameworkOptions
         {
+            // We register built-ins explicitly via ToolCatalog (the trim-safe,
+            // interactive-parity path) and drain them into the registry in
+            // ExecuteAsync, so the framework's own built-in registration stays
+            // off here — same convention as Program.cs/ServiceConfiguration.cs.
             RegisterBuiltInTools = false,
             EnableObservability = false,
             AutoDiscoverTools = false,
         });
 
+        // AX.3: register the built-in tool catalog (file/command/text/git/web/
+        // utility tools) as ToolRegistrationInfo singletons. ExecuteAsync drains
+        // these into the IToolRegistry the SimpleAgent receives.
+        Andy.Cli.Services.ToolCatalog.RegisterAllTools(services);
+
         return services.BuildServiceProvider();
+    }
+
+    // Drains the ToolCatalog's ToolRegistrationInfo entries (registered in
+    // BuildServiceProvider) into the run's IToolRegistry — the same instance
+    // HeadlessToolHost adds config cli/mcp tools to, and the same instance the
+    // SimpleAgent resolves tools from. Mirrors the interactive bootstrap in
+    // Program.cs / ServiceConfiguration.cs.
+    // Internal for testing: see BuildServiceProvider.
+    internal static void RegisterBuiltInTools(IServiceProvider services, ILoggerFactory loggerFactory)
+    {
+        var registry = services.GetRequiredService<IToolRegistry>();
+        var logger = loggerFactory.CreateLogger("Andy.Cli.Headless.HeadlessAgentRunner");
+        var registrations = services.GetServices<Andy.Tools.Framework.ToolRegistrationInfo>();
+        var count = 0;
+        foreach (var registration in registrations)
+        {
+            registry.RegisterTool(registration.ToolType, registration.Configuration);
+            count++;
+        }
+
+        logger.LogInformation("HeadlessAgentRunner: registered {ToolCount} built-in tool(s) into the run registry", count);
     }
 
     // Sets the resolved model on the provider config the factory will pick for

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -106,6 +106,8 @@
     <Compile Include="Headless/HeadlessAgentRunnerStabilityTests.cs" />
     <!-- AQ8 headless contract validation library (rivoli-ai/andy-cli#54) -->
     <Compile Include="HeadlessConfig/HeadlessConfigContractTests.cs" />
+    <!-- AX.3 headless built-in tool availability (rivoli-ai/conductor#2090) -->
+    <Compile Include="Headless/HeadlessBuiltInToolsTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Cli.Tests/Headless/HeadlessBuiltInToolsTests.cs
+++ b/tests/Andy.Cli.Tests/Headless/HeadlessBuiltInToolsTests.cs
@@ -1,0 +1,101 @@
+// AX.3 (rivoli-ai/conductor#2090): headless mode must expose the assistant's
+// built-in tools (read/write/edit files, run command, list dir, ...) in the
+// SAME IToolRegistry the SimpleAgent receives — not just the config-declared
+// cli/mcp tools. Before AX.3 the headless DI registered NO built-in tools.
+//
+// These tests exercise the REAL production wiring (BuildServiceProvider +
+// RegisterBuiltInTools, both internal) so they would FAIL against the old code
+// (registry empty of built-ins) and PASS now.
+
+using System.Linq;
+using Andy.Cli.Headless;
+using Andy.Cli.HeadlessConfig;
+using Andy.Tools.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Cli.Tests.Headless;
+
+public class HeadlessBuiltInToolsTests
+{
+    private static HeadlessRunConfig MinimalConfig() => new()
+    {
+        SchemaVersion = 1,
+        RunId = Guid.NewGuid(),
+        Agent = new HeadlessAgent { Slug = "ax3-agent", Instructions = "stub" },
+        Model = new HeadlessModel { Provider = "stub", Id = "stub-1" },
+        Tools = Array.Empty<HeadlessTool>(),
+        Workspace = new HeadlessWorkspace { Root = System.IO.Path.GetTempPath() },
+        Output = new HeadlessOutput { File = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ax3-out.txt"), Stream = "stdout" },
+        Limits = new HeadlessLimits { MaxIterations = 4, TimeoutSeconds = 30 },
+    };
+
+    private static IToolRegistry BuildRegistryWithBuiltIns()
+    {
+        var services = HeadlessAgentRunner.BuildServiceProvider(MinimalConfig(), NullLoggerFactory.Instance);
+        HeadlessAgentRunner.RegisterBuiltInTools(services, NullLoggerFactory.Instance);
+        return services.GetRequiredService<IToolRegistry>();
+    }
+
+    [Fact]
+    public void Headless_RegistersCoreFileTools()
+    {
+        var registry = BuildRegistryWithBuiltIns();
+        var ids = registry.Tools.Select(t => t.Metadata.Id).ToHashSet(StringComparer.Ordinal);
+
+        // Read-only and mutating file tools are both present (visibility is the
+        // AX.3 concern; AX.4 governs whether mutating ones are *permitted*).
+        Assert.Contains("read_file", ids);
+        Assert.Contains("write_file", ids);
+        Assert.Contains("list_directory", ids);
+    }
+
+    [Fact]
+    public void Headless_RegistersCommandExecutionTool()
+    {
+        var registry = BuildRegistryWithBuiltIns();
+        var ids = registry.Tools.Select(t => t.Metadata.Id).ToHashSet(StringComparer.Ordinal);
+
+        // The "run a command" tool the coding agent needs.
+        Assert.Contains("execute_command", ids);
+    }
+
+    [Fact]
+    public void Headless_BuiltInTools_AreResolvableFromTheRegistry()
+    {
+        var registry = BuildRegistryWithBuiltIns();
+
+        // GetTool is the lookup SimpleAgent uses; prove a built-in resolves.
+        Assert.NotNull(registry.GetTool("read_file"));
+        Assert.NotNull(registry.GetTool("execute_command"));
+    }
+
+    [Fact]
+    public async Task Headless_BuiltInTools_AndConfigTools_Coexist_InSameRegistry()
+    {
+        // A config-declared cli tool added by HeadlessToolHost must land in the
+        // same registry as the built-ins (no clobbering).
+        var config = MinimalConfig();
+        var cliTool = new HeadlessTool
+        {
+            Name = "my_cli_tool",
+            Transport = "cli",
+            Command = OperatingSystem.IsWindows()
+                ? new[] { "cmd", "/c", "echo" }
+                : new[] { "echo" },
+        };
+
+        var services = HeadlessAgentRunner.BuildServiceProvider(config, NullLoggerFactory.Instance);
+        HeadlessAgentRunner.RegisterBuiltInTools(services, NullLoggerFactory.Instance);
+        var registry = services.GetRequiredService<IToolRegistry>();
+
+        // Mirror HeadlessToolHost: register the cli adapter into the same registry.
+        await using var host = await HeadlessToolHost
+            .BuildAsync(new[] { cliTool }, registry, NullLoggerFactory.Instance);
+
+        var ids = registry.Tools.Select(t => t.Metadata.Id).ToHashSet(StringComparer.Ordinal);
+        Assert.Contains("read_file", ids);          // built-in survives
+        Assert.Contains("my_cli_tool", ids);        // config tool present
+    }
+}


### PR DESCRIPTION
Part of rivoli-ai/conductor#2090

## Problem
Headless runs registered **NO** built-in tools. `HeadlessAgentRunner.BuildServiceProvider` set `ToolFrameworkOptions { RegisterBuiltInTools = false, ... }` with an explicit "we deliberately don't register any built-in tools" comment, and `HeadlessToolHost` only registers the config-declared `cli`/`mcp` tools. A headless coding agent therefore had no file/command/text tools at all.

## What changed
Mirror the interactive bootstrap (`Program.cs` / `ServiceConfiguration.cs`):

1. `BuildServiceProvider` now calls `ToolCatalog.RegisterAllTools(services)`, which registers the built-in tool catalog as `ToolRegistrationInfo` singletons in DI (the trim-safe, interactive-parity mechanism — **not** the framework `RegisterBuiltInTools` flag, matching how interactive does it).
2. A new `RegisterBuiltInTools(services, loggerFactory)` step in `ExecuteAsync` drains those `ToolRegistrationInfo` entries into the **same** `IToolRegistry` the `SimpleAgent` receives — the same instance `HeadlessToolHost` then layers the config `cli`/`mcp` tools onto. Built-ins and config tools coexist; nothing is clobbered.

Built-ins now in the headless registry: `read_file`, `write_file`, `copy_file`, `move_file`, `delete_file`, `list_directory`, `create_directory`, `execute_command`, `git_diff`, `search_text`, `replace_text`, `format_text`, `process_info`, `system_info`, `date_time`, `encoding`, `http_request`, `json_processor`, `todo_management`, `code_index`.

`BuildServiceProvider` + `RegisterBuiltInTools` made `internal` (the test assembly already has `InternalsVisibleTo`) so tests exercise the real wiring instead of a parallel reimplementation.

## AX.4 permission caveat (NOT solved here — by design)
Headless wires `AddAndyCliPermissions(services, null)` → **fail-closed, no interactive broker**. So built-ins are now **visible/resolvable** but mutating ones are still **DENIED at execution** with no prompt until AX.4 injects the per-run allow-list.

Specifically, `AppendAskDefaults` marks these as `Ask` → fail-closed deny in headless:
- `write_file`
- `delete_file`
- `move_file`
- `copy_file`
- `file_editor`
- `replace_text`
- `create_directory`

`execute_command` likewise asks via its capability (process-execution permission). Read-only built-ins (`read_file`, `list_directory`, `search_text`, `git_diff`, etc.) stay auto-allowed. **This PR does NOT implement permission injection and does NOT hard-bypass permissions** — AX.4 owns relaxing the above surface.

## Tests
New `tests/Andy.Cli.Tests/Headless/HeadlessBuiltInToolsTests.cs` (xUnit), driving the real DI path:
- `Headless_RegistersCoreFileTools` — `read_file`/`write_file`/`list_directory` present
- `Headless_RegistersCommandExecutionTool` — `execute_command` present
- `Headless_BuiltInTools_AreResolvableFromTheRegistry` — `registry.GetTool(...)` (the lookup `SimpleAgent` uses) resolves built-ins
- `Headless_BuiltInTools_AndConfigTools_Coexist_InSameRegistry` — a config `cli` tool registered via `HeadlessToolHost` lands alongside the built-ins in the same registry

These fail against the old code (registry empty of built-ins) and pass now.

```
# New tests
Passed!  - Failed: 0, Passed: 4, Skipped: 0, Total: 4

# All Headless tests
Passed!  - Failed: 0, Passed: 60, Skipped: 0, Total: 60

# Full Andy.Cli.Tests suite (no regression)
Passed!  - Failed: 0, Passed: 455, Skipped: 1, Total: 456
```
(The 1 skip is the pre-existing credential-dependent `ProviderDetectionServiceTests` case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)