### PR TITLE
[AX.4] andy-cli: permission allow-list injection + tool restriction + audit

### DIFF
--- a/schemas/headless-config.v1.json
+++ b/schemas/headless-config.v1.json
@@ -181,6 +181,22 @@
       "items": { "type": "string" },
       "description": "Policy-derived boundary tags (e.g. 'read-only', 'no-prod', 'draft-only'). Runtime uses these as guard-rails; the authoritative evaluation happens server-side at each tool call."
     },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "AX.4 (rivoli-ai/conductor#2091) per-run permission allow-list. Headless is fail-closed: mutating built-ins (write_file/delete_file/move_file/copy_file/file_editor/replace_text/create_directory) and execute_command default to deny. Tools listed here are relaxed to allow (injected above the builtin defaults); everything else stays denied. Absent = unchanged fail-closed behavior. Populated by AX.9/andy-containers from the resolved policy.",
+      "properties": {
+        "allowed_tools": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_.-]*$"
+          },
+          "description": "Tool ids the run is permitted to execute (e.g. 'write_file', 'execute_command'). A normally-Ask tool becomes executable when listed; a tool not listed stays denied. Empty grants nothing beyond auto-allowed read-only built-ins."
+        }
+      }
+    },
     "limits": {
       "type": "object",
       "required": ["max_iterations", "timeout_seconds"],

--- a/schemas/headless-events.v1.json
+++ b/schemas/headless-events.v1.json
@@ -24,6 +24,7 @@
         "llm_chunk",
         "tool_call_started",
         "tool_call_finished",
+        "tool_usage_audit",
         "output_written",
         "error",
         "finished"
@@ -73,6 +74,31 @@
         "duration_ms": { "type": "integer", "minimum": 0 },
         "result_digest": { "type": "string", "description": "SHA-256 hex of the canonical-JSON-serialized result. Optional; producers MAY omit on error." },
         "error":       { "type": "string", "description": "Short error string when ok=false. Producers SHOULD redact or truncate; consumers MUST NOT key on its content." }
+      }
+    },
+    "tool_usage_audit": {
+      "type": "object",
+      "description": "AX.4 (rivoli-ai/conductor#2091) end-of-run tool-usage audit. Records the distinct tools the agent actually invoked during the run and, for each, whether the permission engine permitted it under the injected allow-list. Lets an external verifier (AX.10) confirm that only permitted tools ran. Emitted once, just before `finished`.",
+      "required": ["allowed_tools", "tools"],
+      "properties": {
+        "allowed_tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "The per-run permission allow-list that was injected (config.permissions.allowed_tools). Empty when none was supplied."
+        },
+        "tools": {
+          "type": "array",
+          "description": "One entry per distinct tool invoked during the run.",
+          "items": {
+            "type": "object",
+            "required": ["tool_name", "invocations", "permitted"],
+            "properties": {
+              "tool_name":   { "type": "string" },
+              "invocations": { "type": "integer", "minimum": 1, "description": "How many times the agent invoked this tool." },
+              "permitted":   { "type": "boolean", "description": "true ⇒ the permission engine permitted this tool (in the allow-list or an auto-allowed read-only built-in); false ⇒ the tool was denied (fail-closed) at execution time." }
+            }
+          }
+        }
       }
     },
     "output_written": {

--- a/schemas/samples/coding-headless.json
+++ b/schemas/samples/coding-headless.json
@@ -48,6 +48,16 @@
     "stream": "stdout"
   },
   "boundaries": ["write-branch", "sandboxed"],
+  "permissions": {
+    "allowed_tools": [
+      "read_file",
+      "write_file",
+      "file_editor",
+      "replace_text",
+      "create_directory",
+      "execute_command"
+    ]
+  },
   "limits": {
     "max_iterations": 400,
     "timeout_seconds": 3600

--- a/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
+++ b/src/Andy.Cli/Headless/HeadlessAgentRunner.cs
@@ -116,7 +116,18 @@ public static class HeadlessAgentRunner
             maxTurns: maxTurns,
             logger: loggerFactory.CreateLogger<SimpleAgent>());
 
-        WireToolEvents(agent, emitter);
+        var auditor = new ToolUsageAuditor();
+        WireToolEvents(agent, emitter, auditor);
+
+        var allowedTools = config.Permissions?.AllowedTools ?? (IReadOnlyList<string>)Array.Empty<string>();
+
+        // Finalize a run that has reached the agent loop: emit the AX.4 tool-usage
+        // audit (once, just before `finished`) then the terminal `finished` event.
+        void Finalize(HeadlessExitCode code, int iters)
+        {
+            EmitToolUsageAudit(emitter, auditor, services, toolHost.Registry, allowedTools);
+            EmitFinished(emitter, stopwatch, iters, code);
+        }
 
         emitter.EmitStarted(
             runId: config.RunId,
@@ -153,14 +164,14 @@ public static class HeadlessAgentRunner
                 emitter.EmitError("Agent loop cancelled.", fatal: true);
                 exitCode = HeadlessExitCode.Cancelled;
             }
-            EmitFinished(emitter, stopwatch, iterations, exitCode);
+            Finalize(exitCode, iterations);
             return exitCode;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Agent loop threw");
             emitter.EmitError($"Agent loop failed: {ex.GetType().Name}: {ex.Message}", fatal: true);
-            EmitFinished(emitter, stopwatch, iterations, HeadlessExitCode.AgentFailure);
+            Finalize(HeadlessExitCode.AgentFailure, iterations);
             return HeadlessExitCode.AgentFailure;
         }
 
@@ -185,7 +196,7 @@ public static class HeadlessAgentRunner
                 emitter.EmitError("Agent loop cancelled.", fatal: true);
                 exitCode = HeadlessExitCode.Cancelled;
             }
-            EmitFinished(emitter, stopwatch, iterations, exitCode);
+            Finalize(exitCode, iterations);
             return exitCode;
         }
 
@@ -207,7 +218,7 @@ public static class HeadlessAgentRunner
                 emitter.EmitError($"Agent loop did not converge: {stopReason}", fatal: true);
                 exitCode = HeadlessExitCode.AgentFailure;
             }
-            EmitFinished(emitter, stopwatch, iterations, exitCode);
+            Finalize(exitCode, iterations);
             return exitCode;
         }
 
@@ -224,11 +235,11 @@ public static class HeadlessAgentRunner
             emitter.EmitError(
                 $"Failed to write output file '{config.Output.File}': {ex.Message}",
                 fatal: true);
-            EmitFinished(emitter, stopwatch, iterations, HeadlessExitCode.AgentFailure);
+            Finalize(HeadlessExitCode.AgentFailure, iterations);
             return HeadlessExitCode.AgentFailure;
         }
 
-        EmitFinished(emitter, stopwatch, iterations, HeadlessExitCode.Success);
+        Finalize(HeadlessExitCode.Success, iterations);
         return HeadlessExitCode.Success;
     }
 
@@ -246,10 +257,13 @@ public static class HeadlessAgentRunner
     // and finishing in the same handler chain. The args themselves stay out
     // of the event stream (digest only) — the producer can't be sure they
     // don't carry secrets.
-    private static void WireToolEvents(SimpleAgent agent, HeadlessEventEmitter emitter)
+    private static void WireToolEvents(SimpleAgent agent, HeadlessEventEmitter emitter, ToolUsageAuditor auditor)
     {
         agent.ToolCalled += (_, e) =>
         {
+            // AX.4: tally every tool the agent invokes for the end-of-run audit.
+            auditor.RecordInvocation(e.ToolName);
+
             var callId = Guid.NewGuid().ToString("N")[..12];
             emitter.EmitToolCallStarted(callId, e.ToolName, argsDigest: null);
             // SimpleAgent does not emit a ToolFinished today; until it does,
@@ -258,6 +272,22 @@ public static class HeadlessAgentRunner
             // stream. Upgrade this when SimpleAgent grows ToolFinished.
             emitter.EmitToolCallFinished(callId, e.ToolName, ok: true, durationMs: 0);
         };
+    }
+
+    // AX.4: emit the end-of-run tool-usage audit just before `finished`, resolving
+    // each invoked tool's permitted status against the live permission engine.
+    private static void EmitToolUsageAudit(
+        HeadlessEventEmitter emitter,
+        ToolUsageAuditor auditor,
+        IServiceProvider services,
+        IToolRegistry registry,
+        IReadOnlyList<string> allowedTools)
+    {
+        var authorizer = services
+            .GetService(typeof(Andy.Permissions.Authorization.IToolPermissionAuthorizer))
+            as Andy.Permissions.Authorization.IToolPermissionAuthorizer;
+        var entries = auditor.BuildEntries(authorizer, registry);
+        emitter.EmitToolUsageAudit(allowedTools, entries);
     }
 
     private static ILlmProvider ResolveLlmProvider(IServiceProvider services, HeadlessRunConfig config)
@@ -392,7 +422,17 @@ public static class HeadlessAgentRunner
         // these into the IToolRegistry the SimpleAgent receives.
         Andy.Cli.Services.ToolCatalog.RegisterAllTools(services);
 
-        return services.BuildServiceProvider();
+        var provider = services.BuildServiceProvider();
+
+        // AX.4 (rivoli-ai/conductor#2091): inject the per-run permission allow-list.
+        // For each tool in config.permissions.allowed_tools, install a {tool}(*) Allow
+        // rule at the Injected layer (precedence 5), which overrides the Builtin "Ask"
+        // defaults (precedence 0). Tools NOT listed stay fail-closed/denied. Absent /
+        // empty list = no-op (unchanged fail-closed behavior).
+        Andy.Cli.Services.CliPermissionServiceExtensions.ApplyInjectedAllowList(
+            provider, config.Permissions?.AllowedTools);
+
+        return provider;
     }
 
     // Drains the ToolCatalog's ToolRegistrationInfo entries (registered in

--- a/src/Andy.Cli/Headless/HeadlessEventEmitter.cs
+++ b/src/Andy.Cli/Headless/HeadlessEventEmitter.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -76,6 +77,24 @@ public sealed class HeadlessEventEmitter : IDisposable
             error
         });
 
+    // AX.4 (rivoli-ai/conductor#2091): end-of-run tool-usage audit. One event listing
+    // the injected allow-list and, per distinct tool the agent invoked, the invocation
+    // count and whether the permission engine permitted it. An external verifier (AX.10)
+    // keys off this to confirm only permitted tools ran.
+    public void EmitToolUsageAudit(
+        IReadOnlyList<string> allowedTools,
+        IReadOnlyList<ToolUsageAuditEntry> tools)
+        => Write(HeadlessEventKind.ToolUsageAudit, new
+        {
+            allowed_tools = allowedTools,
+            tools = tools.Select(t => new
+            {
+                tool_name = t.ToolName,
+                invocations = t.Invocations,
+                permitted = t.Permitted
+            })
+        });
+
     public void EmitOutputWritten(string path, long bytes)
         => Write(HeadlessEventKind.OutputWritten, new { path, bytes });
 
@@ -137,7 +156,12 @@ public enum HeadlessEventKind
     LlmChunk,
     ToolCallStarted,
     ToolCallFinished,
+    ToolUsageAudit,
     OutputWritten,
     Error,
     Finished
 }
+
+// AX.4 (rivoli-ai/conductor#2091): one row of the tool-usage audit — a distinct tool
+// the agent invoked, how many times, and whether the permission engine permitted it.
+public sealed record ToolUsageAuditEntry(string ToolName, int Invocations, bool Permitted);

--- a/src/Andy.Cli/Headless/ToolUsageAuditor.cs
+++ b/src/Andy.Cli/Headless/ToolUsageAuditor.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using Andy.Permissions.Authorization;
+using Andy.Permissions.Model;
+using Andy.Tools.Core;
+
+namespace Andy.Cli.Headless;
+
+// AX.4 (rivoli-ai/conductor#2091): records which tools the headless agent actually
+// invoked during a run and, for each, whether the permission engine permitted it
+// under the injected allow-list. The agent fires ToolCalled when the LLM emits a
+// tool call (before execution); we tally those. The "permitted" verdict is computed
+// from the SAME permission engine that gates execution (IToolPermissionAuthorizer),
+// so the audit reflects the real fail-closed decision rather than guessing:
+//   - Allow  => permitted (in the injected allow-list, or an auto-allowed read-only
+//               built-in).
+//   - Ask    => NOT permitted: headless is non-interactive (no broker), so Ask is
+//               denied at execution time.
+//   - Deny   => NOT permitted.
+//
+// The audit is emitted once at end-of-run (EmitToolUsageAudit) so an external
+// verifier (AX.10) can confirm only permitted tools ran.
+public sealed class ToolUsageAuditor
+{
+    private readonly ConcurrentDictionary<string, int> _invocations = new(StringComparer.Ordinal);
+
+    // Records one invocation of a tool by name. Thread-safe: the post-tool callback
+    // can race with in-flight LLM streaming.
+    public void RecordInvocation(string toolName)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+        {
+            return;
+        }
+
+        _invocations.AddOrUpdate(toolName, 1, static (_, count) => count + 1);
+    }
+
+    // Builds the audit rows, resolving each invoked tool's permitted status against
+    // the live permission engine. <paramref name="authorizer"/> and
+    // <paramref name="registry"/> may be null (e.g. permissions not wired); in that
+    // case "permitted" cannot be evaluated and defaults to false (fail-closed).
+    public IReadOnlyList<ToolUsageAuditEntry> BuildEntries(
+        IToolPermissionAuthorizer? authorizer,
+        IToolRegistry? registry)
+    {
+        return _invocations
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => new ToolUsageAuditEntry(
+                kv.Key,
+                kv.Value,
+                IsPermitted(kv.Key, authorizer, registry)))
+            .ToList();
+    }
+
+    // Asks the permission engine for this tool's effective outcome. Only Allow counts
+    // as permitted under the headless fail-closed contract (Ask has no broker → deny).
+    private static bool IsPermitted(
+        string toolName,
+        IToolPermissionAuthorizer? authorizer,
+        IToolRegistry? registry)
+    {
+        if (authorizer is null)
+        {
+            return false;
+        }
+
+        var metadata = registry?.GetTool(toolName)?.Metadata;
+        var context = new ToolAuthorizationContext(
+            toolName,
+            new Dictionary<string, object?>(),
+            WorkingDirectory: null,
+            Metadata: metadata);
+
+        try
+        {
+            var evaluation = authorizer.Evaluate(context);
+            return evaluation.Outcome == PermissionOutcome.Allow;
+        }
+        catch
+        {
+            // A resolver that needs concrete parameters it doesn't have should not
+            // crash the audit; treat an unresolvable evaluation as not-permitted.
+            return false;
+        }
+    }
+}

--- a/src/Andy.Cli/HeadlessConfig/HeadlessRunConfig.cs
+++ b/src/Andy.Cli/HeadlessConfig/HeadlessRunConfig.cs
@@ -23,7 +23,30 @@ public sealed record HeadlessRunConfig
     public HeadlessEventSink? EventSink { get; init; }
     public Guid? PolicyId { get; init; }
     public IReadOnlyList<string>? Boundaries { get; init; }
+
+    // AX.4 (rivoli-ai/conductor#2091): per-run permission allow-list. Headless is
+    // fail-closed (AddAndyCliPermissions(services, null) → no interactive broker),
+    // so mutating built-ins (write_file/delete_file/move_file/copy_file/file_editor/
+    // replace_text/create_directory) and execute_command resolve to "Ask" → DENY.
+    // This field relaxes EXACTLY the listed tools to "Allow" (injected at the
+    // PermissionLayer.Injected layer, which overrides the Builtin Ask defaults).
+    // Every tool NOT listed stays fail-closed/denied. When ABSENT/null, behavior
+    // is unchanged (current fail-closed defaults) — backward compatible.
+    //
+    // Out of scope here (AX.9 / andy-containers): deriving this list from policies
+    // and writing it into the config. AX.4 only CONSUMES it.
+    public HeadlessPermissions? Permissions { get; init; }
+
     public HeadlessLimits Limits { get; init; } = new();
+}
+
+public sealed record HeadlessPermissions
+{
+    // Tool ids the run is permitted to execute (e.g. "write_file", "execute_command").
+    // A tool that is normally "Ask" (e.g. write_file) becomes executable when listed;
+    // a tool NOT listed stays denied. An empty list grants nothing beyond the
+    // auto-allowed read-only built-ins — same as omitting the block entirely.
+    public IReadOnlyList<string> AllowedTools { get; init; } = [];
 }
 
 public sealed record HeadlessAgent

--- a/src/Andy.Cli/Services/CliPermissionPrompt.cs
+++ b/src/Andy.Cli/Services/CliPermissionPrompt.cs
@@ -236,4 +236,53 @@ public static class CliPermissionServiceExtensions
 
         return list;
     }
+
+    /// <summary>
+    /// AX.4 (rivoli-ai/conductor#2091): inject a per-run permission allow-list into an already-built
+    /// provider's <see cref="IPermissionStore"/>, relaxing EXACTLY the listed tools to
+    /// <see cref="PermissionOutcome.Allow"/>. The rules are installed via
+    /// <see cref="IPermissionStore.SetInjectedRules"/>, which retags every rule to
+    /// <see cref="PermissionLayer.Injected"/> (precedence 5) — strictly above the
+    /// <see cref="PermissionLayer.Builtin"/> (precedence 0) "Ask" defaults that
+    /// <see cref="AppendAskDefaults"/> installs, so a normally-Ask tool such as <c>write_file</c>
+    /// becomes executable. A tool NOT in the list is never granted, so it stays fail-closed/denied.
+    ///
+    /// This is an allow-LIST, not a blanket bypass: each listed tool gets its own
+    /// <c>{tool}(*)</c> Allow rule and nothing else is touched. An empty or null list is a no-op
+    /// (current fail-closed defaults stand).
+    /// </summary>
+    /// <returns>The set of tool ids that were actually injected as Allow rules (de-duplicated).</returns>
+    public static IReadOnlyList<string> ApplyInjectedAllowList(
+        IServiceProvider provider,
+        IReadOnlyList<string>? allowedTools)
+    {
+        if (allowedTools is null || allowedTools.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var store = provider.GetService(typeof(IPermissionStore)) as IPermissionStore;
+        if (store is null)
+        {
+            // No store wired (e.g. permissions not registered) — nothing to relax.
+            return Array.Empty<string>();
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var rules = new List<PermissionRule>();
+        foreach (var tool in allowedTools)
+        {
+            if (string.IsNullOrWhiteSpace(tool) || !seen.Add(tool))
+            {
+                continue;
+            }
+
+            // {tool}(*) at the Injected layer: a tool-scoped Allow that overrides the Builtin Ask
+            // default for this tool only. SetInjectedRules retags to PermissionLayer.Injected.
+            rules.Add(PermissionRule.Parse($"{tool}(*)", PermissionOutcome.Allow, PermissionLayer.Injected));
+        }
+
+        store.SetInjectedRules(rules);
+        return seen.ToList();
+    }
 }

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -108,6 +108,8 @@
     <Compile Include="HeadlessConfig/HeadlessConfigContractTests.cs" />
     <!-- AX.3 headless built-in tool availability (rivoli-ai/conductor#2090) -->
     <Compile Include="Headless/HeadlessBuiltInToolsTests.cs" />
+    <!-- AX.4 permission allow-list injection + tool restriction + audit (rivoli-ai/conductor#2091) -->
+    <Compile Include="Headless/HeadlessPermissionAllowListTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Cli.Tests/Headless/HeadlessPermissionAllowListTests.cs
+++ b/tests/Andy.Cli.Tests/Headless/HeadlessPermissionAllowListTests.cs
@@ -1,0 +1,164 @@
+// AX.4 (rivoli-ai/conductor#2091): a per-run permission allow-list injected into the
+// headless run relaxes EXACTLY the permitted tools; every other (mutating) tool stays
+// fail-closed/denied; and a tool-usage audit records which tools actually ran.
+//
+// These tests exercise the REAL production wiring (BuildServiceProvider, which now calls
+// ApplyInjectedAllowList; ToolUsageAuditor against the live IToolPermissionAuthorizer) so
+// they fail against the pre-AX.4 code (no allow-list → write_file always Ask/deny; no
+// audit) and pass now.
+
+using System.Collections.Generic;
+using System.Linq;
+using Andy.Cli.Headless;
+using Andy.Cli.HeadlessConfig;
+using Andy.Cli.Services;
+using Andy.Permissions.Authorization;
+using Andy.Permissions.Model;
+using Andy.Tools.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Cli.Tests.Headless;
+
+public class HeadlessPermissionAllowListTests
+{
+    private static HeadlessRunConfig Config(IReadOnlyList<string>? allowedTools)
+        => new()
+        {
+            SchemaVersion = 1,
+            RunId = Guid.NewGuid(),
+            Agent = new HeadlessAgent { Slug = "ax4-agent", Instructions = "stub" },
+            Model = new HeadlessModel { Provider = "stub", Id = "stub-1" },
+            Tools = Array.Empty<HeadlessTool>(),
+            Workspace = new HeadlessWorkspace { Root = System.IO.Path.GetTempPath() },
+            Output = new HeadlessOutput
+            {
+                File = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ax4-out.txt"),
+                Stream = "stdout",
+            },
+            Permissions = allowedTools is null ? null : new HeadlessPermissions { AllowedTools = allowedTools },
+            Limits = new HeadlessLimits { MaxIterations = 4, TimeoutSeconds = 30 },
+        };
+
+    // Evaluate a tool's effective permission outcome through the SAME authorizer that
+    // gates execution. Only Allow is executable in headless (no broker for Ask).
+    private static PermissionOutcome Evaluate(ServiceProvider services, string toolName)
+    {
+        var authorizer = services.GetRequiredService<IToolPermissionAuthorizer>();
+        var registry = services.GetRequiredService<IToolRegistry>();
+        var metadata = registry.GetTool(toolName)?.Metadata;
+        var context = new ToolAuthorizationContext(
+            toolName,
+            new Dictionary<string, object?>(),
+            WorkingDirectory: null,
+            Metadata: metadata);
+        return authorizer.Evaluate(context).Outcome;
+    }
+
+    private static ServiceProvider Build(IReadOnlyList<string>? allowedTools)
+    {
+        var services = HeadlessAgentRunner.BuildServiceProvider(Config(allowedTools), NullLoggerFactory.Instance);
+        HeadlessAgentRunner.RegisterBuiltInTools(services, NullLoggerFactory.Instance);
+        return services;
+    }
+
+    [Fact]
+    public void AllowListedMutatingTool_IsAllowed()
+    {
+        // (a) A tool in the allow-list executes (not denied). write_file is normally Ask.
+        using var services = Build(new[] { "write_file" });
+
+        Assert.Equal(PermissionOutcome.Allow, Evaluate(services, "write_file"));
+    }
+
+    [Fact]
+    public void MutatingTool_NotInAllowList_StaysDenied()
+    {
+        // (b) A mutating tool NOT in the allow-list is denied (stays Ask → deny in headless).
+        // Allow-list only relaxes write_file; delete_file must remain non-Allow.
+        using var services = Build(new[] { "write_file" });
+
+        Assert.NotEqual(PermissionOutcome.Allow, Evaluate(services, "delete_file"));
+    }
+
+    [Fact]
+    public void AbsentAllowList_KeepsMutatingToolsDenied()
+    {
+        // (c) Absent allow-list => unchanged fail-closed behavior: write_file is NOT Allow.
+        using var services = Build(allowedTools: null);
+
+        Assert.NotEqual(PermissionOutcome.Allow, Evaluate(services, "write_file"));
+    }
+
+    [Fact]
+    public void EmptyAllowList_KeepsMutatingToolsDenied()
+    {
+        // An explicit empty list grants nothing beyond auto-allowed read-only built-ins.
+        using var services = Build(Array.Empty<string>());
+
+        Assert.NotEqual(PermissionOutcome.Allow, Evaluate(services, "write_file"));
+    }
+
+    [Fact]
+    public void AllowList_DoesNotBypass_ReadOnlyToolsStillAllowed()
+    {
+        // Read-only built-ins are auto-allowed regardless of the allow-list (no regression).
+        using var services = Build(new[] { "write_file" });
+
+        Assert.Equal(PermissionOutcome.Allow, Evaluate(services, "read_file"));
+    }
+
+    [Fact]
+    public void ApplyInjectedAllowList_IsAllowListNotBlanketBypass()
+    {
+        // Injecting one tool must not relax a different unlisted mutating tool.
+        using var services = Build(new[] { "write_file" });
+
+        Assert.Equal(PermissionOutcome.Allow, Evaluate(services, "write_file"));
+        Assert.NotEqual(PermissionOutcome.Allow, Evaluate(services, "move_file"));
+        Assert.NotEqual(PermissionOutcome.Allow, Evaluate(services, "create_directory"));
+    }
+
+    [Fact]
+    public void Audit_RecordsInvokedTools_WithPermittedStatus()
+    {
+        // (d) The audit records invoked tools, and "permitted" reflects the live engine.
+        using var services = Build(new[] { "write_file" });
+        var registry = services.GetRequiredService<IToolRegistry>();
+        var authorizer = services.GetRequiredService<IToolPermissionAuthorizer>();
+
+        var auditor = new ToolUsageAuditor();
+        auditor.RecordInvocation("read_file");      // auto-allowed read-only
+        auditor.RecordInvocation("write_file");     // allow-listed
+        auditor.RecordInvocation("write_file");     // again (count == 2)
+        auditor.RecordInvocation("delete_file");    // not in allow-list → denied
+
+        var entries = auditor.BuildEntries(authorizer, registry);
+
+        Assert.Equal(3, entries.Count);
+
+        var read = entries.Single(e => e.ToolName == "read_file");
+        Assert.Equal(1, read.Invocations);
+        Assert.True(read.Permitted);
+
+        var write = entries.Single(e => e.ToolName == "write_file");
+        Assert.Equal(2, write.Invocations);
+        Assert.True(write.Permitted);
+
+        var delete = entries.Single(e => e.ToolName == "delete_file");
+        Assert.Equal(1, delete.Invocations);
+        Assert.False(delete.Permitted);
+    }
+
+    [Fact]
+    public void ApplyInjectedAllowList_ReturnsDedupedInjectedToolIds()
+    {
+        using var services = Build(allowedTools: null);
+
+        var injected = CliPermissionServiceExtensions.ApplyInjectedAllowList(
+            services, new[] { "write_file", "write_file", "execute_command" });
+
+        Assert.Equal(new[] { "write_file", "execute_command" }, injected);
+    }
+}

--- a/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigSchemaTests.cs
+++ b/tests/Andy.Cli.Tests/HeadlessConfig/HeadlessConfigSchemaTests.cs
@@ -230,6 +230,61 @@ public class HeadlessConfigSchemaTests
         Assert.True(result.IsValid, "openrouter is a supported provider");
     }
 
+    // AX.4 (rivoli-ai/conductor#2091): optional permission allow-list block.
+    [Fact]
+    public void Permissions_AllowedTools_Validates()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["permissions"] = new JsonObject
+        {
+            ["allowed_tools"] = new JsonArray("write_file", "execute_command")
+        };
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.True(result.IsValid, FormatErrors(result));
+    }
+
+    [Fact]
+    public void Permissions_Absent_StillValid()
+    {
+        // Backward compatible: omitting the block keeps the config valid.
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.True(result.IsValid, FormatErrors(result));
+    }
+
+    [Fact]
+    public void Permissions_RejectsUnknownProperty()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["permissions"] = new JsonObject
+        {
+            ["allowed_tools"] = new JsonArray("write_file"),
+            ["bogus"] = true
+        };
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "permissions has additionalProperties:false");
+    }
+
+    [Fact]
+    public void Permissions_RejectsUppercaseToolName()
+    {
+        var schema = LoadSchema();
+        var config = MinimalValidConfig();
+        config["permissions"] = new JsonObject
+        {
+            ["allowed_tools"] = new JsonArray("Write_File")
+        };
+
+        var result = schema.Evaluate(ToElement(config));
+        Assert.False(result.IsValid, "allowed_tools entries must match the tool-name pattern");
+    }
+
     [Fact]
     public void Limits_MaxIterationsZero_Rejected()
     {


### PR DESCRIPTION
Part of rivoli-ai/conductor#2091

## Goal
Inject a per-run **permission allow-list** into the headless run so the assistant may execute **ONLY** the permitted tools; every other tool call is **DENIED** (fail-closed); and record a **tool-usage audit** of which tools actually ran. This is how we prove only intended-permission tools were used.

Background: AX.3 made headless register the built-in tools, but headless wires `AddAndyCliPermissions(services, null)` (no interactive broker) → fail-closed. `AppendAskDefaults` marks mutating built-ins (`write_file`, `delete_file`, `move_file`, `copy_file`, `file_editor`, `replace_text`, `create_directory`) and `execute_command` as **Ask** → denied in headless. AX.4 supplies the allow-list that relaxes EXACTLY the permitted tools.

## Config field shape (for AX.9 / andy-containers to populate)
New optional block on the headless config. **Absent => unchanged fail-closed behavior** (backward compatible).

```jsonc
{
  // ...existing config...
  "permissions": {
    "allowed_tools": ["read_file", "write_file", "file_editor", "execute_command"]
  }
}
```

- `permissions.allowed_tools`: `string[]`, unique items, each matching `^[a-z][a-z0-9_.-]*$` (the tool-name pattern). `additionalProperties: false` on the `permissions` object.
- C# model: `HeadlessRunConfig.Permissions` (`HeadlessPermissions { IReadOnlyList<string> AllowedTools }`).
- Schema updated in `schemas/headless-config.v1.json` (embedded by both `Andy.Cli` and the `Andy.Cli.Headless.Contract` validator, so `HeadlessConfigContract.ValidateConfig` accepts it).
- A worked example is added to `schemas/samples/coding-headless.json`.

**Out of scope (documented for follow-ups):** deriving the allow-list from policies (AX.9) and andy-containers writing it into the config. AX.4 only *consumes* the field.

## Enforcement — Allow-over-Ask layering
For each tool in `permissions.allowed_tools`, `BuildServiceProvider` installs a `{tool}(*)` **Allow** rule via `IPermissionStore.SetInjectedRules(...)`. That API retags every rule to **`PermissionLayer.Injected` (precedence 5)**, which sits strictly above the **`PermissionLayer.Builtin` (precedence 0)** "Ask" defaults `AppendAskDefaults` installs. Result:

- A tool in the list that is normally Ask (e.g. `write_file`) resolves to **Allow** → executable.
- A tool **not** in the list keeps only its Builtin Ask → **denied** (fail-closed).
- Read-only built-ins (`read_file`, ...) stay auto-allowed regardless.

This is an allow-**list**, not a blanket bypass: each listed tool gets its own scoped Allow rule; nothing else is touched. Empty/null list = no-op.

Code: `CliPermissionServiceExtensions.ApplyInjectedAllowList(provider, allowedTools)`; called from `HeadlessAgentRunner.BuildServiceProvider`.

## Audit format
A new `tool_usage_audit` headless event (added to `schemas/headless-events.v1.json`), emitted once just before `finished`:

```jsonc
{
  "schema_version": 1, "ts": "...", "kind": "tool_usage_audit",
  "data": {
    "allowed_tools": ["write_file", "execute_command"],   // the injected allow-list
    "tools": [
      { "tool_name": "read_file",  "invocations": 1, "permitted": true  },
      { "tool_name": "write_file", "invocations": 2, "permitted": true  },
      { "tool_name": "delete_file","invocations": 1, "permitted": false }  // not allow-listed
    ]
  }
}
```

`ToolUsageAuditor` tallies each invoked tool (from `SimpleAgent.ToolCalled`) and computes `permitted` from the **live `IToolPermissionAuthorizer`** (the same engine that gates execution): `Allow` => permitted; `Ask`/`Deny` => not permitted (headless has no broker). An external verifier (AX.10) keys off this to confirm only permitted tools ran.

## Test evidence
New `tests/Andy.Cli.Tests/Headless/HeadlessPermissionAllowListTests.cs` (exercises real `BuildServiceProvider` + live authorizer; fails against pre-AX.4 code):
- (a) allow-listed `write_file` → `Allow`.
- (b) unlisted `delete_file`/`move_file`/`create_directory` → not `Allow` (denied).
- (c) absent allow-list → `write_file` not `Allow` (unchanged fail-closed); empty list likewise.
- read-only `read_file` still `Allow` (no regression); injected ids returned de-duped.
- (d) audit records invoked tools with correct counts + `permitted` status.

New schema cases in `HeadlessConfigSchemaTests.cs`: valid `permissions.allowed_tools`, absent-still-valid, rejects unknown property, rejects uppercase tool name.

```
Headless filter:   72 passed / 0 failed
Full suite:       467 passed / 1 skipped / 0 failed
```
No regression to the AX.3 headless tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)