### PR TITLE
Stop tool spinner on tool return; restore terminal text selection

### DIFF
--- a/src/Andy.Cli/Input/MouseReporting.cs
+++ b/src/Andy.Cli/Input/MouseReporting.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Andy.Cli.Input;
+
+/// <summary>
+/// Tracks and toggles SGR mouse reporting for a terminal.
+///
+/// While mouse reporting is on the terminal forwards mouse events (clicks,
+/// drags, wheel) to the application, which suppresses the terminal emulator's
+/// native click-drag text selection. Turning it off restores native selection.
+/// The CLI only uses mouse events for wheel scrolling, which is also reachable
+/// via PageUp/PageDown, so reporting defaults to off and is opt-in.
+///
+/// The actual terminal writes are routed through an injected sink so the state
+/// machine can be unit-tested without a real TTY.
+/// </summary>
+internal sealed class MouseReporting
+{
+    // 1000 = button tracking (reports wheel as buttons 64/65); 1006 = SGR
+    // extended coordinates. Disable inverts both ('h' -> 'l').
+    internal const string EnableSeq = "\u001b[?1000h\u001b[?1006h";
+    internal const string DisableSeq = "\u001b[?1000l\u001b[?1006l";
+
+    private readonly Action<string> _write;
+    private readonly object _lock = new();
+    private bool _enabled;
+
+    public MouseReporting(Action<string> write)
+        => _write = write ?? throw new ArgumentNullException(nameof(write));
+
+    /// <summary>Current reporting state.</summary>
+    public bool Enabled
+    {
+        get { lock (_lock) return _enabled; }
+    }
+
+    /// <summary>
+    /// Set reporting on or off and return the new state. Writes the matching
+    /// escape sequence only on an actual state change; a failed write is
+    /// swallowed (best effort) but the tracked state still advances.
+    /// </summary>
+    public bool Set(bool enabled)
+    {
+        lock (_lock)
+        {
+            if (enabled == _enabled) return _enabled;
+            try { _write(enabled ? EnableSeq : DisableSeq); }
+            catch { /* ignore: best effort, terminal may be gone */ }
+            _enabled = enabled;
+            return _enabled;
+        }
+    }
+
+    /// <summary>Flip reporting and return the new state.</summary>
+    public bool Toggle()
+    {
+        lock (_lock) return Set(!_enabled);
+    }
+}

--- a/src/Andy.Cli/Input/RawTerminalInput.cs
+++ b/src/Andy.Cli/Input/RawTerminalInput.cs
@@ -12,10 +12,12 @@ namespace Andy.Cli.Input;
 /// existing keyboard handling.
 ///
 /// On start it puts the TTY into cbreak mode via <c>stty</c> (no echo, no
-/// canonical line buffering, CR left untranslated), enables SGR mouse reporting,
-/// and spins a background thread that polls fd 0 and feeds bytes through
-/// <see cref="TerminalInputParser"/>. Decoded events are queued for the main
-/// loop to drain. The original terminal settings and mouse mode are restored on
+/// canonical line buffering, CR left untranslated) and spins a background thread
+/// that polls fd 0 and feeds bytes through <see cref="TerminalInputParser"/>.
+/// Decoded events are queued for the main loop to drain. SGR mouse reporting is
+/// off by default (so the terminal's native click-drag text selection keeps
+/// working) and can be toggled at runtime via <see cref="SetMouseReporting"/>.
+/// The original terminal settings and mouse mode are restored on
 /// <see cref="Dispose"/>, process exit, and Ctrl+C.
 ///
 /// Input is read with libc <c>poll</c>/<c>read</c> on fd 0 rather than
@@ -40,20 +42,15 @@ public sealed class RawTerminalInput : IDisposable
     private readonly ConcurrentQueue<TerminalInputEvent> _queue = new();
     private readonly Thread _thread;
     private readonly string _savedStty;
-    private readonly bool _mouseEnabled;
+    private readonly MouseReporting _mouse;
     private volatile bool _stop;
     private int _restored; // 0 = not yet restored, 1 = restored (guards idempotency)
 
     private RawTerminalInput(string savedStty, bool enableMouse)
     {
         _savedStty = savedStty;
-        if (enableMouse)
-        {
-            // 1000 = button tracking (reports wheel as buttons 64/65),
-            // 1006 = SGR extended coordinates.
-            Console.Write("\u001b[?1000h\u001b[?1006h");
-            _mouseEnabled = true;
-        }
+        _mouse = new MouseReporting(Console.Write);
+        if (enableMouse) _mouse.Set(true);
 
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
         Console.CancelKeyPress += OnCancelKeyPress;
@@ -63,11 +60,30 @@ public sealed class RawTerminalInput : IDisposable
     }
 
     /// <summary>
+    /// Whether SGR mouse reporting is currently enabled. When on, the terminal
+    /// forwards mouse events to the app and native click-drag text selection is
+    /// suppressed.
+    /// </summary>
+    public bool MouseEnabled => _mouse.Enabled;
+
+    /// <summary>
+    /// Turn SGR mouse reporting on or off at runtime and return the new state.
+    /// </summary>
+    public bool SetMouseReporting(bool enabled) => _mouse.Set(enabled);
+
+    /// <summary>Flip mouse reporting and return the new state.</summary>
+    public bool ToggleMouseReporting() => _mouse.Toggle();
+
+    /// <summary>
     /// Attempt to switch the terminal into raw byte mode. Returns <c>null</c>
     /// when input is not an interactive TTY or <c>stty</c> is unavailable, in
     /// which case the caller should keep using <c>Console.ReadKey</c>.
+    ///
+    /// <paramref name="enableMouse"/> defaults to <c>false</c> so the terminal's
+    /// native click-drag text selection keeps working out of the box; callers
+    /// can opt in up front or flip it later via <see cref="SetMouseReporting"/>.
     /// </summary>
-    public static RawTerminalInput? TryStart(bool enableMouse)
+    public static RawTerminalInput? TryStart(bool enableMouse = false)
     {
         if (Console.IsInputRedirected) return null;
 
@@ -145,7 +161,9 @@ public sealed class RawTerminalInput : IDisposable
     {
         // Run at most once across Dispose / ProcessExit / Ctrl+C.
         if (Interlocked.Exchange(ref _restored, 1) != 0) return;
-        try { if (_mouseEnabled) Console.Write("\u001b[?1000l\u001b[?1006l"); } catch { /* ignore */ }
+        // Always disable mouse reporting on the way out if it was ever enabled,
+        // so the terminal is left with native click-drag selection restored.
+        SetMouseReporting(false);
         try { RunStty(_savedStty, out _); } catch { /* ignore */ }
     }
 

--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -186,11 +186,12 @@ class Program
         Console.Write("[49m");
         Console.Clear();
 
-        // Switch the terminal into raw byte mode so we can receive mouse wheel
-        // events. Returns null (and we fall back to Console.ReadKey) when input
-        // is redirected or stty is unavailable. Mouse reporting is only enabled
-        // when this succeeds, since Console.ReadKey cannot decode mouse bytes.
-        var rawInput = RawTerminalInput.TryStart(enableMouse: true);
+        // Switch the terminal into raw byte mode for keyboard decoding. Returns
+        // null (and we fall back to Console.ReadKey) when input is redirected or
+        // stty is unavailable. Mouse reporting starts OFF so the terminal's
+        // native click-drag text selection keeps working; the user can toggle
+        // mouse-wheel capture on with F3 (PageUp/PageDown scroll either way).
+        var rawInput = RawTerminalInput.TryStart(enableMouse: false);
 
         try
         {
@@ -697,6 +698,7 @@ class Program
                             "- **Ctrl+]**: Toggle scroll mode (Feed ↔ Prompt History)\n" +
                             "- **Ctrl+D**: Quit application\n" +
                             "- **F2**: Toggle HUD (performance overlay)\n" +
+                            "- **F3**: Toggle mouse capture (off = native text selection; on = mouse-wheel scroll)\n" +
                             "- **ESC**: Quit application\n" +
                             "- **Page Up/Down**: Scroll chat history\n" +
                             "- **↑/↓**: Navigate multi-line text or prompt history (when in History mode)\n" +
@@ -967,6 +969,27 @@ class Program
                     }
                     if (k.Key == ConsoleKey.F2) { hud.Enabled = !hud.Enabled; return; }
 
+                    // F3 toggles mouse capture. Mouse capture is off by default
+                    // so the terminal's native click-drag text selection works;
+                    // turning it on enables mouse-wheel scrolling of the feed at
+                    // the cost of suppressing native selection. Wheel scrolling
+                    // is also available via PageUp/PageDown regardless.
+                    if (k.Key == ConsoleKey.F3)
+                    {
+                        if (rawInput == null)
+                        {
+                            toast.Show("Mouse capture unavailable (no raw terminal)", 90);
+                        }
+                        else
+                        {
+                            bool on = rawInput.ToggleMouseReporting();
+                            toast.Show(on
+                                ? "Mouse capture ON (wheel scrolls; native text selection disabled)"
+                                : "Mouse capture OFF (native text selection enabled)", 120);
+                        }
+                        return;
+                    }
+
                     // Handle Ctrl+P / Cmd+P for command palette
                     if (k.Key == ConsoleKey.P && (k.Modifiers & ConsoleModifiers.Control) != 0)
                     {
@@ -1190,6 +1213,7 @@ class Program
                                         "- **Ctrl+]**: Toggle scroll mode (Feed ↔ Prompt History)\n" +
                                         "- **Ctrl+D**: Quit application\n" +
                                         "- **F2**: Toggle HUD (performance overlay)\n" +
+                            "- **F3**: Toggle mouse capture (off = native text selection; on = mouse-wheel scroll)\n" +
                                         "- **ESC**: Quit application\n" +
                                         "- **Page Up/Down**: Scroll chat history\n" +
                                         "- **↑/↓**: Navigate multi-line text or prompt history (when in History mode)\n" +

--- a/src/Andy.Cli/Services/SimpleAssistantService.cs
+++ b/src/Andy.Cli/Services/SimpleAssistantService.cs
@@ -20,7 +20,10 @@ public class SimpleAssistantService : IDisposable
     private readonly ILogger<SimpleAssistantService>? _logger;
     private readonly string _modelName;
     private readonly string _providerName;
-    private readonly Dictionary<string, (DateTime startTime, Dictionary<string, object?>? parameters)> _runningTools = new();
+    // Concurrent: mutated from the agent's ToolCalled callback (background agent thread) and read/
+    // removed from the end-of-turn completion loop. A plain Dictionary raced across these threads and
+    // could corrupt internally, surfacing as a NullReferenceException that aborted the whole turn.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, (DateTime startTime, Dictionary<string, object?>? parameters)> _runningTools = new();
     private int _toolCallCounter = 0;
     private int _lastInputTokens = 0;
     private int _lastOutputTokens = 0;
@@ -125,17 +128,11 @@ public class SimpleAssistantService : IDisposable
             };
             _feed.AddToolExecutionStart(toolId, e.ToolName, initialParams);
 
-            // Schedule completion after a reasonable timeout if not completed naturally
-            _ = Task.Run(async () =>
-            {
-                await Task.Delay(TimeSpan.FromSeconds(30));
-                if (_runningTools.ContainsKey(toolId))
-                {
-                    var elapsed = DateTime.UtcNow - _runningTools[toolId].startTime;
-                    _feed.AddToolExecutionComplete(toolId, true, FormatDuration(elapsed), "Completed");
-                    _runningTools.Remove(toolId);
-                }
-            });
+            // The spinner is stopped by UiUpdatingToolExecutor the instant the tool returns, and the
+            // end-of-turn loop below is the backstop for anything it missed. A previous 30s background
+            // timer here both spuriously marked still-running tools "Completed" and, by mutating
+            // _runningTools from a stray thread pool task (often one left over from a prior turn), raced
+            // the dictionary into the NullReferenceException that crashed the turn.
         };
     }
 
@@ -410,7 +407,7 @@ public class SimpleAssistantService : IDisposable
                 InstrumentationHub.Instance.Publish(toolCompleteEvent);
 
                 _feed.AddToolExecutionComplete(tool.Key, isSuccess, durationStr, resultSummary);
-                _runningTools.Remove(tool.Key);
+                _runningTools.TryRemove(tool.Key, out _);
             }
 
             // Calculate actual duration

--- a/src/Andy.Cli/Services/UiUpdatingToolExecutor.cs
+++ b/src/Andy.Cli/Services/UiUpdatingToolExecutor.cs
@@ -106,8 +106,12 @@ namespace Andy.Cli.Services
                 }
             }
 
-            // Execute the actual tool (parameters cannot be null here based on interface contract)
+            // Execute the actual tool (parameters cannot be null here based on interface contract).
+            // Time it so the UI can show the tool's real duration the moment it returns, rather
+            // than the whole-turn elapsed measured later by SimpleAssistantService.
+            var toolStopwatch = System.Diagnostics.Stopwatch.StartNew();
             var result = await _innerExecutor.ExecuteAsync(toolId, parameters ?? new Dictionary<string, object?>(), context);
+            toolStopwatch.Stop();
 
             // Track completion and update UI with result
             // IMPORTANT: We must track completion BEFORE SimpleAssistantService tries to read it
@@ -476,6 +480,15 @@ namespace Andy.Cli.Services
 
                 ToolExecutionTracker.Instance.TrackToolComplete(uiToolId, result.IsSuccessful, resultMessage, result.Data);
 
+                // Stop the spinner immediately now that the tool has returned data. Previously the
+                // running-tool item was only marked complete by SimpleAssistantService after the whole
+                // agent turn (including the final model response) finished, so the spinner and elapsed
+                // timer appeared to hang long after the tool was actually done. AddToolExecutionComplete
+                // is idempotent, so the later end-of-turn pass is a harmless no-op for this tool.
+                var feedViewForCompletion = ToolExecutionTracker.Instance.GetFeedView();
+                feedViewForCompletion?.AddToolExecutionComplete(
+                    uiToolId, result.IsSuccessful, FormatToolDuration(toolStopwatch.Elapsed), resultMessage);
+
                 // INSTRUMENTATION: Publish event when tool result is about to be sent back to LLM
                 var toolResultToLlmEvent = new ToolResultToLlmEvent
                 {
@@ -509,6 +522,16 @@ namespace Andy.Cli.Services
         /// Andy.Permissions gate decides actual consent per call; these flags only stop the lower-level
         /// capability checks from blocking a tool before the gate runs.
         /// </summary>
+        /// <summary>Format an elapsed tool duration the same way the feed status line does.</summary>
+        private static string FormatToolDuration(TimeSpan elapsed)
+        {
+            if (elapsed.TotalMilliseconds < 1000)
+                return $"{elapsed.TotalMilliseconds:F0}ms";
+            if (elapsed.TotalSeconds < 60)
+                return $"{elapsed.TotalSeconds:F1}s";
+            return $"{elapsed.TotalMinutes:F1}m";
+        }
+
         private static void GrantGatedCapabilities(ToolExecutionContext context)
         {
             context.Permissions.FileSystemAccess = true;

--- a/src/Andy.Cli/Widgets/FeedView.cs
+++ b/src/Andy.Cli/Widgets/FeedView.cs
@@ -405,6 +405,13 @@ namespace Andy.Cli.Widgets
                 {
                     if (_items[i] is RunningToolItem runningTool && runningTool.ToolId == toolId)
                     {
+                        // Idempotent: the tool executor marks completion the instant the tool
+                        // returns (stopping the spinner with the tool's real duration). A later
+                        // end-of-turn pass must not overwrite that with the whole-turn elapsed.
+                        if (runningTool.IsComplete)
+                        {
+                            break;
+                        }
                         runningTool.SetComplete(success, duration);
                         if (!string.IsNullOrEmpty(result))
                         {

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -81,6 +81,8 @@
     <Compile Include="Input/MouseReportingTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
+    <!-- Tool spinner completion + concurrency regression tests -->
+    <Compile Include="Services/ToolSpinnerCompletionTests.cs" />
     <!-- Parallel tool execution tests -->
     <Compile Include="Services/ParallelToolExecutionTests.cs" />
     <Compile Include="Services/CliPermissionPromptTests.cs" />

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -77,6 +77,8 @@
     <Compile Include="Widgets/CommandOutputWidthTests.cs" />
     <!-- Raw terminal input decoder tests (mouse wheel + keyboard) -->
     <Compile Include="Input/TerminalInputParserTests.cs" />
+    <!-- Mouse reporting enable/disable tests -->
+    <Compile Include="Input/MouseReportingTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
     <!-- Parallel tool execution tests -->

--- a/tests/Andy.Cli.Tests/Input/MouseReportingTests.cs
+++ b/tests/Andy.Cli.Tests/Input/MouseReportingTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using Andy.Cli.Input;
+using Xunit;
+
+namespace Andy.Cli.Tests.Input;
+
+/// <summary>
+/// Tests for <see cref="MouseReporting"/>, the SGR mouse-reporting toggle.
+///
+/// Mouse reporting suppresses the terminal's native click-drag text selection,
+/// so the CLI keeps it off by default and only writes the enable/disable escape
+/// sequences on an actual state change. These tests pin the exact init/teardown
+/// sequences and the toggle/idempotency behavior using a fake write sink.
+/// </summary>
+public class MouseReportingTests
+{
+    private static MouseReporting NewWithSink(out List<string> writes)
+    {
+        var captured = new List<string>();
+        writes = captured;
+        return new MouseReporting(captured.Add);
+    }
+
+    [Fact]
+    public void StartsDisabled_AndWritesNothing()
+    {
+        var m = NewWithSink(out var writes);
+
+        Assert.False(m.Enabled);
+        Assert.Empty(writes);
+    }
+
+    [Fact]
+    public void Enable_WritesExactEnableSequence()
+    {
+        var m = NewWithSink(out var writes);
+
+        bool now = m.Set(true);
+
+        Assert.True(now);
+        Assert.True(m.Enabled);
+        Assert.Equal(new[] { MouseReporting.EnableSeq }, writes);
+    }
+
+    [Fact]
+    public void EnableSequence_TurnsOnButtonTrackingAndSgrCoordinates()
+    {
+        // 1000h = button tracking, 1006h = SGR extended coordinates.
+        Assert.Equal("\u001b[?1000h\u001b[?1006h", MouseReporting.EnableSeq);
+    }
+
+    [Fact]
+    public void DisableSequence_IsTheInverseOfEnable()
+    {
+        // Same modes, terminated with 'l' (reset) instead of 'h' (set).
+        Assert.Equal("\u001b[?1000l\u001b[?1006l", MouseReporting.DisableSeq);
+        Assert.Equal(
+            MouseReporting.EnableSeq.Replace('h', 'l'),
+            MouseReporting.DisableSeq);
+    }
+
+    [Fact]
+    public void EnableThenDisable_WritesBothSequencesInOrder()
+    {
+        var m = NewWithSink(out var writes);
+
+        m.Set(true);
+        bool now = m.Set(false);
+
+        Assert.False(now);
+        Assert.False(m.Enabled);
+        Assert.Equal(new[] { MouseReporting.EnableSeq, MouseReporting.DisableSeq }, writes);
+    }
+
+    [Fact]
+    public void SettingSameState_IsIdempotent_NoExtraWrites()
+    {
+        var m = NewWithSink(out var writes);
+
+        m.Set(true);
+        m.Set(true); // no-op
+        Assert.Single(writes);
+
+        m.Set(false);
+        m.Set(false); // no-op
+        Assert.Equal(2, writes.Count);
+    }
+
+    [Fact]
+    public void DisableWhileAlreadyOff_WritesNothing()
+    {
+        var m = NewWithSink(out var writes);
+
+        bool now = m.Set(false);
+
+        Assert.False(now);
+        Assert.Empty(writes);
+    }
+
+    [Fact]
+    public void Toggle_FlipsStateAndEmitsMatchingSequences()
+    {
+        var m = NewWithSink(out var writes);
+
+        Assert.True(m.Toggle());  // off -> on
+        Assert.False(m.Toggle()); // on -> off
+        Assert.True(m.Toggle());  // off -> on
+
+        Assert.Equal(
+            new[] { MouseReporting.EnableSeq, MouseReporting.DisableSeq, MouseReporting.EnableSeq },
+            writes);
+    }
+
+    [Fact]
+    public void FailedWrite_DoesNotThrow_ButStillAdvancesState()
+    {
+        var m = new MouseReporting(_ => throw new System.IO.IOException("terminal gone"));
+
+        bool now = m.Set(true);
+
+        Assert.True(now);
+        Assert.True(m.Enabled);
+    }
+}

--- a/tests/Andy.Cli.Tests/Services/ToolSpinnerCompletionTests.cs
+++ b/tests/Andy.Cli.Tests/Services/ToolSpinnerCompletionTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Andy.Cli.Services;
+using Andy.Cli.Widgets;
+using Andy.Tools.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services
+{
+    /// <summary>
+    /// Regression tests for the tool-execution spinner lifecycle.
+    ///
+    /// Bug: the running-tool spinner (and its elapsed timer) only stopped when
+    /// SimpleAssistantService ran its end-of-turn completion loop, which happens
+    /// after the whole agent turn — including the final model response — finishes.
+    /// So a tool that returned in 12ms appeared to hang for the rest of the turn.
+    /// The fix moves UI completion into UiUpdatingToolExecutor, the instant the
+    /// tool returns its data.
+    /// </summary>
+    public class ToolSpinnerCompletionTests
+    {
+        private static RunningToolItem? FindTool(FeedView feed, string toolId)
+        {
+            return feed.GetItemsForTesting()
+                .OfType<RunningToolItem>()
+                .FirstOrDefault(t => t.ToolId == toolId);
+        }
+
+        private static string? ReadDuration(RunningToolItem item)
+        {
+            var field = typeof(RunningToolItem).GetField("_duration",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            return field?.GetValue(item) as string;
+        }
+
+        [Fact]
+        public async Task Spinner_StopsWhenToolReturns_WithoutEndOfTurnLoop()
+        {
+            // Arrange: a unique tool id/name so we don't collide with the
+            // process-wide ToolExecutionTracker singleton across tests.
+            var suffix = Guid.NewGuid().ToString("N")[..8];
+            var toolName = $"unit_tool_{suffix}";
+            var uiToolId = $"{toolName}_1";
+
+            var feed = new FeedView();
+            ToolExecutionTracker.Instance.SetFeedView(feed);
+
+            // Mirror what SimpleAssistantService.ToolCalled does: create the UI
+            // spinner and enqueue the pending tool so the executor can claim it.
+            feed.AddToolExecutionStart(uiToolId, toolName);
+            ToolExecutionTracker.Instance.EnqueuePendingTool(toolName, uiToolId);
+
+            var gate = new TaskCompletionSource();
+            var inner = new GatedToolExecutor(gate.Task, "all done");
+            var uiExecutor = new UiUpdatingToolExecutor(inner, NullLogger<UiUpdatingToolExecutor>.Instance);
+
+            // Act: start execution but keep the tool blocked.
+            var execTask = uiExecutor.ExecuteAsync(toolName, new Dictionary<string, object?>(), null);
+
+            // While the tool runs, the spinner must still be spinning.
+            var duringRun = FindTool(feed, uiToolId);
+            Assert.NotNull(duringRun);
+            Assert.False(duringRun!.IsComplete);
+
+            // Let the tool return.
+            gate.SetResult();
+            var result = await execTask;
+
+            // Assert: completion happened at tool-return time — no end-of-turn
+            // loop was ever run in this test.
+            Assert.True(result.IsSuccessful);
+            var afterRun = FindTool(feed, uiToolId);
+            Assert.NotNull(afterRun);
+            Assert.True(afterRun!.IsComplete);
+        }
+
+        [Fact]
+        public void EndOfTurnPass_DoesNotOverwrite_ExecutorCompletion()
+        {
+            // The executor stops the spinner with the tool's real duration; the
+            // later end-of-turn pass calls AddToolExecutionComplete again with the
+            // whole-turn elapsed. That second call must be a no-op so the accurate
+            // duration survives.
+            var feed = new FeedView();
+            var toolId = $"idemp_{Guid.NewGuid():N}";
+
+            feed.AddToolExecutionStart(toolId, "idemp_tool");
+            feed.AddToolExecutionComplete(toolId, success: true, duration: "12ms", result: "done");
+            feed.AddToolExecutionComplete(toolId, success: true, duration: "9.9s", result: "stale");
+
+            var item = FindTool(feed, toolId);
+            Assert.NotNull(item);
+            Assert.True(item!.IsComplete);
+            Assert.Equal("12ms", ReadDuration(item));
+        }
+
+        [Fact]
+        public async Task ConcurrentStartAndComplete_DoesNotThrow()
+        {
+            // Guards the shared running-tool surface against the kind of cross-thread
+            // access that previously raced an unsynchronized dictionary into a
+            // NullReferenceException mid-turn.
+            var feed = new FeedView();
+            const int count = 200;
+
+            var tasks = Enumerable.Range(0, count).Select(i => Task.Run(() =>
+            {
+                var id = $"race_{i}";
+                feed.AddToolExecutionStart(id, "race_tool");
+                feed.AddToolExecutionComplete(id, success: true, duration: "1ms", result: "ok");
+            }));
+
+            // Should complete without throwing.
+            await Task.WhenAll(tasks);
+
+            var completed = feed.GetItemsForTesting()
+                .OfType<RunningToolItem>()
+                .Count(t => t.ToolId.StartsWith("race_") && t.IsComplete);
+            Assert.Equal(count, completed);
+        }
+
+        /// <summary>Inner executor whose completion is gated on an external task.</summary>
+        private sealed class GatedToolExecutor : IToolExecutor
+        {
+            private readonly Task _gate;
+            private readonly string _data;
+
+            public GatedToolExecutor(Task gate, string data)
+            {
+                _gate = gate;
+                _data = data;
+            }
+
+#pragma warning disable CS0067 // events required by IToolExecutor but unused by this fake
+            public event EventHandler<ToolExecutionStartedEventArgs>? ExecutionStarted;
+            public event EventHandler<ToolExecutionCompletedEventArgs>? ExecutionCompleted;
+            public event EventHandler<SecurityViolationEventArgs>? SecurityViolation;
+#pragma warning restore CS0067
+
+            public async Task<ToolExecutionResult> ExecuteAsync(string toolId, Dictionary<string, object?> parameters, ToolExecutionContext? context = null)
+            {
+                await _gate;
+                return new ToolExecutionResult
+                {
+                    IsSuccessful = true,
+                    Message = "Successfully executed",
+                    Data = _data
+                };
+            }
+
+            public Task<ToolExecutionResult> ExecuteAsync(ToolExecutionRequest request)
+                => ExecuteAsync(request.ToolId, request.Parameters, request.Context);
+
+            public Task<IList<string>> ValidateExecutionRequestAsync(ToolExecutionRequest request)
+                => Task.FromResult<IList<string>>(new List<string>());
+
+            public Task<ToolResourceUsage?> EstimateResourceUsageAsync(string toolId, Dictionary<string, object?> parameters)
+                => Task.FromResult<ToolResourceUsage?>(null);
+
+            public Task<int> CancelExecutionsAsync(string correlationId) => Task.FromResult(0);
+
+            public IReadOnlyList<RunningExecutionInfo> GetRunningExecutions() => new List<RunningExecutionInfo>();
+
+            public ToolExecutionStatistics GetStatistics() => new ToolExecutionStatistics();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two independent tool-execution / TUI fixes that were reported together.

### 1. Tool spinner hangs until the whole turn finishes
The running-tool spinner and elapsed timer only stopped when `SimpleAssistantService` ran its end-of-turn completion loop — which fires *after* the entire agent turn (including the final model response) completes. A tool that returned in milliseconds appeared to hang for the rest of the turn.

- `UiUpdatingToolExecutor` now stops the spinner the instant the tool returns, stamping the tool's real duration.
- `FeedView.AddToolExecutionComplete` is made idempotent so the later end-of-turn pass can't overwrite the accurate duration.
- `_runningTools` hardened from a plain `Dictionary` (mutated concurrently by the `ToolCalled` callback, a 30s timer, and the end-of-turn loop) to a `ConcurrentDictionary`; the redundant 30s timer — which also spuriously marked live tools "Completed" — is removed.

### 2. Can't select / copy text with the mouse
The terminal had SGR mouse reporting (`?1000h`) enabled, so it forwarded clicks/drags to the app and suppressed native text selection — even though the app only consumes the scroll wheel. Mouse capture now defaults **off** (native selection / copy-paste works; scroll via PgUp/PgDn), with a runtime toggle retained.

## Tests
- `ToolSpinnerCompletionTests` — spinner completes on tool return, idempotent end-of-turn completion, concurrent start/complete without throwing.
- `MouseReportingTests` — enable/disable sequencing and state.

All Widgets/Services/Input suites pass (0 failures).