### PR TITLE
Suppress engine conversation-history dump when the agent hits its turn limit

### DIFF
--- a/src/Andy.Cli/Services/SimpleAssistantService.cs
+++ b/src/Andy.Cli/Services/SimpleAssistantService.cs
@@ -21,6 +21,14 @@ public class SimpleAssistantService : IDisposable
     private readonly string _modelName;
     private readonly string _providerName;
     private readonly Dictionary<string, (DateTime startTime, Dictionary<string, object?>? parameters)> _runningTools = new();
+    // Max agent turns (LLM round-trips, each of which may issue tool calls) per user
+    // message. When this is hit the engine stops with StopReason "max_turns_exceeded"
+    // and returns a full conversation-history dump as its response (see the guard in
+    // ProcessMessageAsync). 10 was far too low for real coding tasks, which routinely
+    // need a dozen+ explore/edit round-trips.
+    private const int MaxAgentTurns = 50;
+    private const string MaxTurnsStopReason = "max_turns_exceeded";
+
     private int _toolCallCounter = 0;
     private int _lastInputTokens = 0;
     private int _lastOutputTokens = 0;
@@ -66,7 +74,7 @@ public class SimpleAssistantService : IDisposable
             toolRegistry,
             uiExecutor,  // Use the wrapped executor
             systemPrompt,
-            maxTurns: 10,
+            maxTurns: MaxAgentTurns,
             logger: logger as ILogger<SimpleAgent>
         );
 
@@ -442,24 +450,23 @@ public class SimpleAssistantService : IDisposable
                 _feed.AddItem(new Andy.Cli.Widgets.SpacerItem(1));
             }
 
-            // Add response to pipeline
-            if (!string.IsNullOrEmpty(result.Response))
+            // Add response to pipeline. On the turn-limit path the engine returns the FULL
+            // conversation history (raw tool payloads, embedded CRLFs and all) as the response;
+            // SelectResponseContent replaces that with a concise notice so it doesn't flood the feed.
+            if (IsMaxTurnsExceeded(result.StopReason))
             {
-                pipeline.AddRawContent(result.Response);
+                _logger?.LogWarning("Agent hit the {MaxTurns}-turn limit; suppressing history dump", MaxAgentTurns);
             }
             else if (!result.Success)
             {
-                // Error case - show the error
                 _logger?.LogWarning("Agent failed. StopReason: {StopReason}", result.StopReason);
-                pipeline.AddRawContent($"**Error**: Agent failed with StopReason: {result.StopReason}");
             }
-            else
+            else if (string.IsNullOrEmpty(result.Response))
             {
-                // No response content - this is unexpected
                 _logger?.LogWarning("Agent returned empty response. Success: {Success}, StopReason: {StopReason}",
                     result.Success, result.StopReason);
-                pipeline.AddRawContent($"[No response received. StopReason: {result.StopReason}]");
             }
+            pipeline.AddRawContent(SelectResponseContent(result.Response, result.Success, result.StopReason));
 
             // Context line disabled to avoid rendering issues
             // pipeline.AddSystemMessage("", SystemMessageType.Context, priority: 1999);
@@ -469,6 +476,12 @@ public class SimpleAssistantService : IDisposable
 
             await pipeline.FinalizeAsync();
             pipeline.Dispose();
+
+            // Don't propagate the raw history dump as the return value either.
+            if (IsMaxTurnsExceeded(result.StopReason))
+            {
+                return $"[Reached the {MaxAgentTurns}-turn tool-call limit before completing this request.]";
+            }
 
             return result.Response ?? string.Empty;
         }
@@ -554,6 +567,33 @@ public class SimpleAssistantService : IDisposable
     {
         // Conservative estimate: 1 token ≈ 4 characters
         return Math.Max(1, characterCount / 4);
+    }
+
+    /// <summary>True when the agent stopped because it exhausted its turn budget.</summary>
+    internal static bool IsMaxTurnsExceeded(string? stopReason) =>
+        string.Equals(stopReason, MaxTurnsStopReason, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Decide what to render for an agent result. On the turn-limit path the engine packs the
+    /// entire conversation history into the response; we replace it with a short notice so the
+    /// feed isn't flooded with raw tool JSON and CRLFs.
+    /// </summary>
+    internal static string SelectResponseContent(string? response, bool success, string? stopReason)
+    {
+        if (IsMaxTurnsExceeded(stopReason))
+        {
+            return $"**Reached the {MaxAgentTurns}-turn tool-call limit** before completing this request. " +
+                   "Partial work above may be incomplete - try narrowing the task or asking it to continue.";
+        }
+        if (!string.IsNullOrEmpty(response))
+        {
+            return response;
+        }
+        if (!success)
+        {
+            return $"**Error**: Agent failed with StopReason: {stopReason}";
+        }
+        return $"[No response received. StopReason: {stopReason}]";
     }
 
     private static string FormatDuration(TimeSpan elapsed)

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -79,6 +79,8 @@
     <Compile Include="Input/TerminalInputParserTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
+    <!-- Turn-limit response handling (suppress engine history dump) -->
+    <Compile Include="Services/MaxTurnsResponseTests.cs" />
     <!-- Parallel tool execution tests -->
     <Compile Include="Services/ParallelToolExecutionTests.cs" />
     <Compile Include="Services/CliPermissionPromptTests.cs" />

--- a/tests/Andy.Cli.Tests/Services/MaxTurnsResponseTests.cs
+++ b/tests/Andy.Cli.Tests/Services/MaxTurnsResponseTests.cs
@@ -1,0 +1,74 @@
+using Andy.Cli.Services;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services
+{
+    /// <summary>
+    /// Regression tests for the turn-limit response handling.
+    ///
+    /// Bug: when the agent exhausts its turn budget, Andy.Engine returns the FULL
+    /// conversation history (every raw tool-result payload, with embedded CRLFs from
+    /// e.g. an HTTP error body) as the response, with StopReason "max_turns_exceeded".
+    /// The CLI rendered that verbatim, flooding the feed with raw tool JSON and a wall
+    /// of blank lines. SelectResponseContent must replace it with a concise notice.
+    /// </summary>
+    public class MaxTurnsResponseTests
+    {
+        // A representative slice of the engine's history dump, including the CRLFs that
+        // showed up in the feed (from a GitHub 403 HTML body embedded in a tool result).
+        private const string HistoryDump =
+            "Conversation history (FULL - no truncation):\r\n" +
+            "[3] Role: Tool\r\nContent: {\"success\":true}\r\nToolCalls Count: 1\r\n" +
+            "  - ToolResult: http_request (CallId: abc, IsError: True)\r\n\r\n\r\n\r\n";
+
+        [Theory]
+        [InlineData("max_turns_exceeded")]
+        [InlineData("MAX_TURNS_EXCEEDED")]
+        public void IsMaxTurnsExceeded_MatchesCaseInsensitively(string stopReason)
+        {
+            Assert.True(SimpleAssistantService.IsMaxTurnsExceeded(stopReason));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("completed")]
+        [InlineData("stop")]
+        public void IsMaxTurnsExceeded_FalseForOthers(string? stopReason)
+        {
+            Assert.False(SimpleAssistantService.IsMaxTurnsExceeded(stopReason));
+        }
+
+        [Fact]
+        public void TurnLimit_SuppressesHistoryDump_AndShowsNotice()
+        {
+            // Even though a (huge, dump-shaped) response is present, the turn-limit path
+            // must not render it.
+            var content = SimpleAssistantService.SelectResponseContent(
+                HistoryDump, success: false, stopReason: "max_turns_exceeded");
+
+            Assert.DoesNotContain("Role:", content);
+            Assert.DoesNotContain("ToolCalls Count", content);
+            Assert.DoesNotContain("Conversation history", content);
+            Assert.DoesNotContain("\r\n", content);
+            Assert.Contains("turn", content); // the concise notice mentions the turn limit
+        }
+
+        [Fact]
+        public void NormalResponse_PassesThrough()
+        {
+            var content = SimpleAssistantService.SelectResponseContent(
+                "Here is the answer.", success: true, stopReason: "completed");
+            Assert.Equal("Here is the answer.", content);
+        }
+
+        [Fact]
+        public void EmptyFailedResponse_ShowsError()
+        {
+            var content = SimpleAssistantService.SelectResponseContent(
+                response: "", success: false, stopReason: "provider_error");
+            Assert.Contains("Error", content);
+            Assert.Contains("provider_error", content);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Asking the agent to do a non-trivial task (e.g. "work on issue #21") floods the feed with a wall of raw tool JSON and a screenful of blank lines / stray CRLFs, instead of a usable answer.

### Root cause
When the agent exhausts its turn budget, `Andy.Engine` stops with `StopReason = "max_turns_exceeded"` and returns the **entire conversation history** — every raw tool-result payload, including embedded `\r\n` (e.g. from a GitHub 403 HTML error body) and full file contents — as `result.Response`. The CLI rendered that verbatim.

Two compounding factors:
1. The CLI hardcoded `maxTurns: 10`, which real coding tasks blow past routinely, so the limit (and the dump) was hit on ordinary requests.
2. There was no guard against rendering the turn-limit response, so the raw history landed in the feed.

This is not a crash (no `crash.log` entry) — it's debug output leaking into the UI.

## Fix
- Extract `SelectResponseContent(...)`: on `max_turns_exceeded` it renders a concise notice ("Reached the 50-turn tool-call limit before completing this request…") instead of the raw history; the method's return value no longer propagates the dump either.
- Raise `maxTurns` 10 → 50 so ordinary multi-step tasks complete normally.

## Tests
`MaxTurnsResponseTests` — asserts the dump (incl. `\r\n`, `Role:`, `ToolCalls Count`, `Conversation history`) is suppressed and replaced with the notice, plus case-insensitive stop-reason matching and the normal/error passthrough paths. 9/9 pass.

## Notes
- The deeper issue — the engine returning a raw history dump as a user-facing response — lives in the `Andy.Engine` package and is worth fixing upstream; this CLI-side guard neutralizes it regardless.
- Independent of #110 (spinner/mouse). Both touch `SimpleAssistantService.cs` and the test csproj, so whichever merges second will need a trivial conflict resolution.