### PR TITLE
Loop guard: short-circuit repeated identical tool calls

### DIFF
--- a/src/Andy.Cli/Services/ToolCallLoopDetector.cs
+++ b/src/Andy.Cli/Services/ToolCallLoopDetector.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Andy.Cli.Services
+{
+    /// <summary>
+    /// Detects tight tool-call loops: the same (tool, arguments) signature recurring within a
+    /// sliding window of recent calls. Lets <see cref="UiUpdatingToolExecutor"/> short-circuit a
+    /// runaway repeat (e.g. the model calling the same query over and over making no progress)
+    /// with guidance to the model instead of re-running the tool and burning tokens.
+    ///
+    /// Scope: catches exact-identical repeats only (low false-positive). Varied-argument
+    /// "no-progress" spinning is left to the turn-limit guard. Thread-safe.
+    /// </summary>
+    internal sealed class ToolCallLoopDetector
+    {
+        private readonly int _window;
+        private readonly int _threshold;
+        private readonly Queue<string> _recent = new();
+        private readonly object _lock = new();
+
+        /// <param name="window">How many of the most recent calls to consider.</param>
+        /// <param name="threshold">
+        /// Occurrences of the same signature within the window at which a call is treated as a loop.
+        /// With the default 3, the third identical call in the window is the first to be flagged.
+        /// </param>
+        public ToolCallLoopDetector(int window = 8, int threshold = 3)
+        {
+            if (window < 1) throw new ArgumentOutOfRangeException(nameof(window));
+            if (threshold < 1) throw new ArgumentOutOfRangeException(nameof(threshold));
+            _window = window;
+            _threshold = threshold;
+        }
+
+        /// <summary>
+        /// Record a call signature and report whether it has now occurred at least
+        /// <c>threshold</c> times within the most recent <c>window</c> calls (i.e. this call
+        /// looks like a loop and should be short-circuited).
+        /// </summary>
+        public bool RecordAndIsLooping(string signature)
+        {
+            lock (_lock)
+            {
+                _recent.Enqueue(signature);
+                while (_recent.Count > _window) _recent.Dequeue();
+
+                int count = 0;
+                foreach (var s in _recent)
+                {
+                    if (s == signature) count++;
+                }
+                return count >= _threshold;
+            }
+        }
+
+        /// <summary>Build a stable signature from a tool id and its parameters (order-independent).</summary>
+        public static string Signature(string toolId, IReadOnlyDictionary<string, object?>? parameters)
+        {
+            if (parameters == null || parameters.Count == 0) return toolId;
+            var parts = parameters
+                .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => $"{kv.Key}={kv.Value}");
+            return toolId + "|" + string.Join("&", parts);
+        }
+    }
+}

--- a/src/Andy.Cli/Services/UiUpdatingToolExecutor.cs
+++ b/src/Andy.Cli/Services/UiUpdatingToolExecutor.cs
@@ -16,6 +16,7 @@ namespace Andy.Cli.Services
     {
         private readonly IToolExecutor _innerExecutor;
         private readonly ILogger<UiUpdatingToolExecutor>? _logger;
+        private readonly ToolCallLoopDetector _loopDetector = new();
 
         public event EventHandler<ToolExecutionStartedEventArgs>? ExecutionStarted
         {
@@ -104,6 +105,31 @@ namespace Andy.Cli.Services
                     // Update ONLY this specific tool by exact ID (critical for parallel executions)
                     feedView.UpdateToolByExactId(uiToolId, parameters);
                 }
+            }
+
+            // Loop guard: if the model keeps issuing the same call with identical arguments, it is
+            // almost certainly stuck (and burning tokens). Short-circuit with guidance instead of
+            // re-running the tool, so it stops repeating and changes approach.
+            var loopSignature = ToolCallLoopDetector.Signature(toolId, parameters);
+            if (_loopDetector.RecordAndIsLooping(loopSignature))
+            {
+                var guidance =
+                    $"Loop guard: the tool '{toolId}' has already been called repeatedly with identical " +
+                    "arguments and returned the same result. Stop repeating this call - use the results you " +
+                    "already have, or take a different approach to make progress.";
+                _logger?.LogWarning("[UI_EXECUTOR] Loop detected for {ToolId}; short-circuiting. Signature={Signature}",
+                    toolId, loopSignature);
+
+                if (!string.IsNullOrEmpty(uiToolId))
+                {
+                    ToolExecutionTracker.Instance.TrackToolComplete(uiToolId, false, guidance, null);
+                }
+
+                return new ToolExecutionResult
+                {
+                    IsSuccessful = false,
+                    Message = guidance
+                };
             }
 
             // Execute the actual tool (parameters cannot be null here based on interface contract)

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -79,6 +79,8 @@
     <Compile Include="Input/TerminalInputParserTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
+    <!-- Tool-call loop detection (short-circuit repeated identical calls) -->
+    <Compile Include="Services/ToolCallLoopDetectionTests.cs" />
     <!-- Parallel tool execution tests -->
     <Compile Include="Services/ParallelToolExecutionTests.cs" />
     <Compile Include="Services/CliPermissionPromptTests.cs" />

--- a/tests/Andy.Cli.Tests/Services/ToolCallLoopDetectionTests.cs
+++ b/tests/Andy.Cli.Tests/Services/ToolCallLoopDetectionTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Andy.Cli.Services;
+using Andy.Cli.Widgets;
+using Andy.Tools.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services
+{
+    /// <summary>
+    /// Tests for the tool-call loop guard: repeated identical (tool, args) calls within a sliding
+    /// window are short-circuited so the agent stops spinning and burning tokens.
+    /// </summary>
+    public class ToolCallLoopDetectionTests
+    {
+        [Fact]
+        public void Detector_FlagsThirdIdenticalCall_WithDefaults()
+        {
+            var d = new ToolCallLoopDetector(window: 8, threshold: 3);
+            Assert.False(d.RecordAndIsLooping("a")); // 1st
+            Assert.False(d.RecordAndIsLooping("a")); // 2nd
+            Assert.True(d.RecordAndIsLooping("a"));  // 3rd -> loop
+            Assert.True(d.RecordAndIsLooping("a"));  // keeps flagging
+        }
+
+        [Fact]
+        public void Detector_DistinctSignatures_NeverFlag()
+        {
+            var d = new ToolCallLoopDetector(window: 8, threshold: 3);
+            for (int i = 0; i < 8; i++)
+            {
+                Assert.False(d.RecordAndIsLooping($"sig_{i}"));
+            }
+        }
+
+        [Fact]
+        public void Detector_OldOccurrencesFallOutOfWindow()
+        {
+            // window 3, threshold 2: two "a"s separated by enough other calls never coexist.
+            var d = new ToolCallLoopDetector(window: 3, threshold: 2);
+            Assert.False(d.RecordAndIsLooping("a")); // [a]
+            Assert.False(d.RecordAndIsLooping("b")); // [a,b]
+            Assert.False(d.RecordAndIsLooping("c")); // [a,b,c]
+            Assert.False(d.RecordAndIsLooping("a")); // [b,c,a] - only one "a" in window
+        }
+
+        [Fact]
+        public void Signature_IsOrderIndependent()
+        {
+            var p1 = new Dictionary<string, object?> { ["b"] = 2, ["a"] = 1 };
+            var p2 = new Dictionary<string, object?> { ["a"] = 1, ["b"] = 2 };
+            Assert.Equal(
+                ToolCallLoopDetector.Signature("t", p1),
+                ToolCallLoopDetector.Signature("t", p2));
+        }
+
+        [Fact]
+        public void Signature_DiffersByArgs()
+        {
+            var a = ToolCallLoopDetector.Signature("code_index", new Dictionary<string, object?> { ["q"] = "symbols" });
+            var b = ToolCallLoopDetector.Signature("code_index", new Dictionary<string, object?> { ["q"] = "references" });
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public async Task Executor_ShortCircuitsRepeatedIdenticalCalls()
+        {
+            var inner = new CountingToolExecutor();
+            var uiExecutor = new UiUpdatingToolExecutor(inner, NullLogger<UiUpdatingToolExecutor>.Instance);
+
+            var feed = new FeedView();
+            ToolExecutionTracker.Instance.SetFeedView(feed);
+
+            var toolName = $"loop_tool_{Guid.NewGuid():N}";
+            var args = new Dictionary<string, object?> { ["query_type"] = "symbols" };
+
+            int executed = 0, blocked = 0;
+            for (int i = 0; i < 5; i++)
+            {
+                // Mirror SimpleAssistantService.ToolCalled enqueueing a UI id per call.
+                ToolExecutionTracker.Instance.EnqueuePendingTool(toolName, $"{toolName}_{i}");
+                var r = await uiExecutor.ExecuteAsync(toolName, new Dictionary<string, object?>(args), null);
+                if (r.IsSuccessful) executed++;
+                else if ((r.Message ?? "").Contains("Loop guard")) blocked++;
+            }
+
+            // With threshold 3, the first two run for real; the rest are short-circuited.
+            Assert.Equal(2, inner.Calls);
+            Assert.Equal(2, executed);
+            Assert.Equal(3, blocked);
+        }
+
+        private sealed class CountingToolExecutor : IToolExecutor
+        {
+            public int Calls { get; private set; }
+
+#pragma warning disable CS0067 // required by interface, unused here
+            public event EventHandler<ToolExecutionStartedEventArgs>? ExecutionStarted;
+            public event EventHandler<ToolExecutionCompletedEventArgs>? ExecutionCompleted;
+            public event EventHandler<SecurityViolationEventArgs>? SecurityViolation;
+#pragma warning restore CS0067
+
+            public Task<ToolExecutionResult> ExecuteAsync(string toolId, Dictionary<string, object?> parameters, ToolExecutionContext? context = null)
+            {
+                Calls++;
+                return Task.FromResult(new ToolExecutionResult { IsSuccessful = true, Message = "ok", Data = "data" });
+            }
+
+            public Task<ToolExecutionResult> ExecuteAsync(ToolExecutionRequest request)
+                => ExecuteAsync(request.ToolId, request.Parameters, request.Context);
+
+            public Task<IList<string>> ValidateExecutionRequestAsync(ToolExecutionRequest request)
+                => Task.FromResult<IList<string>>(new List<string>());
+
+            public Task<ToolResourceUsage?> EstimateResourceUsageAsync(string toolId, Dictionary<string, object?> parameters)
+                => Task.FromResult<ToolResourceUsage?>(null);
+
+            public Task<int> CancelExecutionsAsync(string correlationId) => Task.FromResult(0);
+
+            public IReadOnlyList<RunningExecutionInfo> GetRunningExecutions() => new List<RunningExecutionInfo>();
+
+            public ToolExecutionStatistics GetStatistics() => new ToolExecutionStatistics();
+        }
+    }
+}


### PR DESCRIPTION
Closes #112.

## Problem
The model can spiral into the same tool call with identical arguments (observed live: the same `code_index` query 6+ times, ~52k output tokens on a single "work on #21" request), making no progress until it hits the turn limit.

## Fix
- New `ToolCallLoopDetector` — a thread-safe sliding window of recent `(tool, canonicalized-args)` signatures. When the same signature recurs >= threshold (default 3) times within the window (default 8), the call is flagged as a loop.
- Wired into `UiUpdatingToolExecutor`: a flagged call is **short-circuited** — instead of re-running the tool, it returns a guidance result ("you've called this repeatedly with identical args and the same result; stop repeating and change approach"), which feeds back to the model and breaks the loop. The UI spinner is completed with the guidance.

This is the [Gemini CLI loop-detection](https://github.com/google-gemini/gemini-cli/discussions/23240) pattern.

## Scope / limitations
- Catches **exact-identical** `(tool, args)` repeats only (low false-positive). Varied-argument "no-progress" spinning stays backstopped by the turn-limit guard (#111).
- The detector lives for the session; an old signature ages out of the window quickly, so cross-turn false positives are unlikely. Per-turn reset can be added later if needed.

## Tests
`ToolCallLoopDetectionTests` (6): window/threshold flagging, distinct-signature no-flag, window eviction, order-independent + arg-sensitive signatures, and an executor-level test asserting the inner executor runs only `threshold-1` times across 5 identical calls (rest short-circuited).

## Notes
- Independent PR off `origin/main`. Touches `UiUpdatingToolExecutor.cs`, which #110 also modifies — whichever merges second needs a trivial conflict resolution.
- Companion follow-ups tracked in #113 (wrap-up nudge) and #114 (compaction) — both need Andy.Engine hooks.