### PR TITLE
Bump Andy.Engine to 2026.6.15-rc.54 (clean turn-limit response + wrap-up nudge)

### DIFF
--- a/src/Andy.Cli/Andy.Cli.csproj
+++ b/src/Andy.Cli/Andy.Cli.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Andy.Acp.Core" Version="2025.11.18-rc.3" />
     <PackageReference Include="Andy.CodeIndex.Infrastructure" Version="2026.6.8-rc.3" />
-    <PackageReference Include="Andy.Engine" Version="2026.6.15-rc.52" />
+    <PackageReference Include="Andy.Engine" Version="2026.6.15-rc.54" />
     <PackageReference Include="Andy.Llm" Version="2026.6.7-rc.38" />
     <PackageReference Include="Andy.MCP" Version="2026.4.26-rc.29" />
     <PackageReference Include="Andy.Model" Version="2026.5.31-rc.8" />


### PR DESCRIPTION
Bumps `Andy.Engine` 2026.6.15-rc.52 -> 2026.6.15-rc.54.

rc.54 (rivoli-ai/andy-engine#13) fixes the turn-limit behavior at the source:
- On `max_turns_exceeded`, the engine now returns a **concise notice** instead of packing the entire raw conversation history (tool JSON + embedded CRLFs) into the response — the root cause of the "wall of tool info" the feed rendered verbatim (#111).
- Adds a **wrap-up nudge** as the agent nears its turn budget so it can finish before the hard stop (#113).

The CLI-side changes remain as complementary defense-in-depth:
- #111 (turn-limit response handling + maxTurns 10->50)
- #112/#115 (loop guard for repeated identical tool calls)

## Verification
- `dotnet restore`/`build` clean on rc.54.
- 373 CLI tests pass (Services/Widgets/Input/Headless), incl. Headless runner tests that exercise the engine end-to-end.

Merge after #110/#111/#115 (or in any order — this only touches the csproj package version).