### PR TITLE
Wire engine/tool loggers via ILoggerFactory (they were always null)

### DIFF
--- a/src/Andy.Cli/Program.cs
+++ b/src/Andy.Cli/Program.cs
@@ -421,7 +421,7 @@ class Program
                 }
 
                 var toolExecutor = serviceProvider.GetRequiredService<IToolExecutor>();
-                var logger = serviceProvider.GetService<ILogger<SimpleAssistantService>>();
+                var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
                 aiService = new SimpleAssistantService(
                     llmProvider,
                     toolRegistry,
@@ -430,7 +430,7 @@ class Program
                     currentModel,
                     currentProvider,
                     tokenCounter,
-                    logger);
+                    loggerFactory);
 
                 var providerUrl = GetProviderUrl(currentProvider);
 
@@ -530,7 +530,7 @@ class Program
                                     aiService?.Dispose();
 
                                     var toolExecutor = serviceProvider.GetRequiredService<IToolExecutor>();
-                                    var logger = serviceProvider.GetService<ILogger<SimpleAssistantService>>();
+                                    var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
                                     aiService = new SimpleAssistantService(
                                         llmProvider,
                                         toolRegistry,
@@ -539,7 +539,7 @@ class Program
                                         newModel,
                                         newProvider,
                                         tokenCounter,
-                                        logger);
+                                        loggerFactory);
                                 }
 
                                 feed.AddMarkdownRich($"*Note: Conversation context reset for {modelCommand.GetCurrentProvider()} model*");
@@ -1162,7 +1162,7 @@ class Program
                                                 aiService?.Dispose();
 
                                                 var toolExecutor = serviceProvider.GetRequiredService<IToolExecutor>();
-                                                var logger = serviceProvider.GetService<ILogger<SimpleAssistantService>>();
+                                                var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
                                                 aiService = new SimpleAssistantService(
                                                     llmProvider,
                                                     toolRegistry,
@@ -1171,7 +1171,7 @@ class Program
                                                     newModel,
                                                     newProvider,
                                                     tokenCounter,
-                                                    logger);
+                                                    loggerFactory);
                                             }
 
                                             feed.AddMarkdownRich($"*Note: Conversation context reset for {modelCommand.GetCurrentProvider()} model*");

--- a/src/Andy.Cli/Services/SimpleAssistantService.cs
+++ b/src/Andy.Cli/Services/SimpleAssistantService.cs
@@ -17,6 +17,7 @@ public class SimpleAssistantService : IDisposable
     private readonly SimpleAgent _agent;
     private readonly FeedView _feed;
     private readonly TokenCounter? _tokenCounter;
+    private readonly ILoggerFactory? _loggerFactory;
     private readonly ILogger<SimpleAssistantService>? _logger;
     private readonly string _modelName;
     private readonly string _providerName;
@@ -33,11 +34,16 @@ public class SimpleAssistantService : IDisposable
         string modelName,
         string providerName,
         TokenCounter? tokenCounter = null,
-        ILogger<SimpleAssistantService>? logger = null)
+        ILoggerFactory? loggerFactory = null)
     {
         _feed = feed;
         _tokenCounter = tokenCounter;
-        _logger = logger;
+        // Take an ILoggerFactory so each collaborator gets a correctly-typed logger. Previously a
+        // single ILogger<SimpleAssistantService> was passed and `as ILogger<SimpleAgent>` / etc.
+        // were used, which always yield null (the generic types are unrelated) - so engine-, tool-,
+        // and pipeline-level logs silently went nowhere in the real app.
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory?.CreateLogger<SimpleAssistantService>();
         _modelName = modelName;
         _providerName = providerName;
 
@@ -58,7 +64,7 @@ public class SimpleAssistantService : IDisposable
         InstrumentationHub.Instance.SetSystemPrompt(systemPrompt);
 
         // Wrap the tool executor to update UI when tools execute
-        var uiExecutor = new UiUpdatingToolExecutor(toolExecutor, logger as ILogger<UiUpdatingToolExecutor>);
+        var uiExecutor = new UiUpdatingToolExecutor(toolExecutor, loggerFactory?.CreateLogger<UiUpdatingToolExecutor>());
 
         // Create the SimpleAgent
         _agent = new SimpleAgent(
@@ -67,7 +73,7 @@ public class SimpleAssistantService : IDisposable
             uiExecutor,  // Use the wrapped executor
             systemPrompt,
             maxTurns: 10,
-            logger: logger as ILogger<SimpleAgent>
+            logger: loggerFactory?.CreateLogger<SimpleAgent>()
         );
 
         // Subscribe to agent events for UI updates
@@ -152,8 +158,8 @@ public class SimpleAssistantService : IDisposable
             // Create new content pipeline for this request
             var processor = new MarkdownContentProcessor();
             var sanitizer = new TextContentSanitizer();
-            var renderer = new FeedContentRenderer(_feed, _logger as ILogger<FeedContentRenderer>);
-            var pipeline = new ContentPipeline.ContentPipeline(processor, sanitizer, renderer, _logger as ILogger<ContentPipeline.ContentPipeline>);
+            var renderer = new FeedContentRenderer(_feed, _loggerFactory?.CreateLogger<FeedContentRenderer>());
+            var pipeline = new ContentPipeline.ContentPipeline(processor, sanitizer, renderer, _loggerFactory?.CreateLogger<ContentPipeline.ContentPipeline>());
 
             // Local shortcut: answer simple environment questions without LLM
             if (LooksLikeCurrentDirectoryQuery(userMessage))

--- a/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
+++ b/tests/Andy.Cli.Tests/Andy.Cli.Tests.csproj
@@ -79,6 +79,8 @@
     <Compile Include="Input/TerminalInputParserTests.cs" />
     <!-- Code indexing tests -->
     <Compile Include="Tools/CodeIndexToolTests.cs" />
+    <!-- Engine/tool logger wiring (ILoggerFactory) regression -->
+    <Compile Include="Services/SimpleAssistantServiceLoggerWiringTests.cs" />
     <!-- Parallel tool execution tests -->
     <Compile Include="Services/ParallelToolExecutionTests.cs" />
     <Compile Include="Services/CliPermissionPromptTests.cs" />

--- a/tests/Andy.Cli.Tests/Services/SimpleAssistantServiceLoggerWiringTests.cs
+++ b/tests/Andy.Cli.Tests/Services/SimpleAssistantServiceLoggerWiringTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Andy.Cli.Services;
+using Andy.Cli.Widgets;
+using Andy.Model.Llm;
+using Andy.Tools.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Cli.Tests.Services
+{
+    /// <summary>
+    /// Regression: SimpleAssistantService used to receive a single ILogger&lt;SimpleAssistantService&gt;
+    /// and cast it with `as ILogger&lt;SimpleAgent&gt;` / `as ILogger&lt;UiUpdatingToolExecutor&gt;`, which
+    /// always yields null (unrelated generic types) — so engine- and tool-level logs went nowhere in
+    /// the real app. It now takes an ILoggerFactory and creates correctly-typed loggers.
+    /// </summary>
+    public class SimpleAssistantServiceLoggerWiringTests
+    {
+        [Fact]
+        public void Constructor_CreatesTypedLoggers_ForEngineAndToolExecutor()
+        {
+            var factory = new RecordingLoggerFactory();
+
+            var registry = new Mock<IToolRegistry>();
+            registry.Setup(r => r.GetTools(
+                    It.IsAny<ToolCategory?>(), It.IsAny<ToolCapability?>(),
+                    It.IsAny<IEnumerable<string>?>(), It.IsAny<bool>()))
+                .Returns(new List<ToolRegistration>());
+
+            using var service = new SimpleAssistantService(
+                Mock.Of<ILlmProvider>(),
+                registry.Object,
+                Mock.Of<IToolExecutor>(),
+                new FeedView(),
+                modelName: "model-x",
+                providerName: "provider-x",
+                tokenCounter: null,
+                loggerFactory: factory);
+
+            // The factory must have been asked for properly-typed loggers — the whole point of the
+            // fix. Previously these collaborators silently got null.
+            Assert.Contains(factory.Categories, c => c.Contains("SimpleAgent"));
+            Assert.Contains(factory.Categories, c => c.Contains("UiUpdatingToolExecutor"));
+            Assert.Contains(factory.Categories, c => c.Contains("SimpleAssistantService"));
+        }
+
+        [Fact]
+        public void Constructor_DoesNotThrow_WhenLoggerFactoryIsNull()
+        {
+            var registry = new Mock<IToolRegistry>();
+            registry.Setup(r => r.GetTools(
+                    It.IsAny<ToolCategory?>(), It.IsAny<ToolCapability?>(),
+                    It.IsAny<IEnumerable<string>?>(), It.IsAny<bool>()))
+                .Returns(new List<ToolRegistration>());
+
+            // The factory is optional; null must remain safe (no logging, no crash).
+            using var service = new SimpleAssistantService(
+                Mock.Of<ILlmProvider>(),
+                registry.Object,
+                Mock.Of<IToolExecutor>(),
+                new FeedView(),
+                modelName: "m",
+                providerName: "p",
+                tokenCounter: null,
+                loggerFactory: null);
+
+            Assert.NotNull(service);
+        }
+
+        private sealed class RecordingLoggerFactory : ILoggerFactory
+        {
+            public List<string> Categories { get; } = new();
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                Categories.Add(categoryName);
+                return NullLogger.Instance;
+            }
+
+            public void AddProvider(ILoggerProvider provider) { }
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`SimpleAssistantService` was given a single `ILogger<SimpleAssistantService>` and built its collaborators' loggers by casting it:

```csharp
new UiUpdatingToolExecutor(toolExecutor, logger as ILogger<UiUpdatingToolExecutor>);
new SimpleAgent(..., logger: logger as ILogger<SimpleAgent>);
new FeedContentRenderer(_feed, _logger as ILogger<FeedContentRenderer>);
new ContentPipeline(..., _logger as ILogger<ContentPipeline>);
```

`ILogger<A> as ILogger<B>` is **always null** (the generic types are unrelated), so engine-, tool-, renderer-, and pipeline-level logs silently went nowhere in the real app. This now matters more: as of `Andy.Engine` rc.54 the engine writes the conversation-history detail to its **log** (instead of returning it) on max-turns — useless if that logger is null.

## Fix
Take an `ILoggerFactory` and create correctly-typed loggers from it (`CreateLogger<T>()`). The three `SimpleAssistantService` construction sites in `Program.cs` now pass the `ILoggerFactory` from the service provider.

## Tests
`SimpleAssistantServiceLoggerWiringTests`:
- asserts the factory is asked for the `SimpleAgent`, `UiUpdatingToolExecutor`, and `SimpleAssistantService` loggers (i.e. real loggers, not null);
- asserts a null factory stays safe.

64 Services tests pass.

## Note
Touches `SimpleAssistantService.cs` (constructor signature), which #111 also modifies — trivial conflict on whichever merges second. Pairs naturally with the rc.54 bump (#116).